### PR TITLE
Fix/local-login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ frontend/static/frontend/js
 frontend/static/frontend/css
 tsc/
 frontend/cypress/videos
+frontend/cypress/screenshots
 coverage/
 
 .vscode


### PR DESCRIPTION
- Replace the usage of `axios` with `fetch` (only on login). Axios, while great, is too abstracted and doesn't provide the configuration I need to prevent the browser generate login popup from showing when login fails.

I should have caught this easily with the cypress e2e tests but forgot to run then before merging. I think this should be part of our review process.