### PR TITLE
Much faster estimated count

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -101,16 +101,16 @@ class Operation(BaseEntity):
     def __str__(self):
         return self.name
 
-    def build_query(self, limit=None, offset=None):
+    def build_query(self, limit=None, offset=None, estimate_count=None):
         """Build an SQL query"""
-        count_query = QueryBuilder(self).count_sql()
+        count_query = QueryBuilder(self).count_sql(estimate_count)
         if limit is None:
             return (count_query, QueryBuilder(self).get_sql_without_limit())
         return (count_query, QueryBuilder(self).get_sql(limit, offset))
 
-    def query_table(self, limit, offset):
+    def query_table(self, limit, offset, estimate_count):
         """Build a query then execute it to return the matching data"""
-        return fetch_data(self.build_query(limit, offset))
+        return fetch_data(self.build_query(limit, offset, estimate_count))
 
 
 class OperationStep(BaseEntity):

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -26,7 +26,7 @@ class DataSerializer(serializers.BaseSerializer):
         if limit == 0:
             limit = DEFAULT_LIMIT_COUNT
         operation = instance['operation_instance']
-        count, data = operation.query_table(limit, offset)
+        count, data = operation.query_table(limit, offset, estimate_count=True)
 
         return {
             'count': count,


### PR DESCRIPTION
Cuts the amount of time for a small query in about half:
```
time python manage.py shell -c 'from core.models import Operation; one=Operation.objects.get(pk=1); print(one.query_table(1, 1, True));'
real	0m0.667s
user	0m0.506s
sys	0m0.058s

time python manage.py shell -c 'from core.models import Operation; one=Operation.objects.get(pk=1); print(one.query_table(1, 1, False));'
real	0m1.339s
user	0m0.496s
sys	0m0.055s

```