### PR TITLE
Err handling db manager

### DIFF
--- a/data/db_manager.py
+++ b/data/db_manager.py
@@ -1,17 +1,32 @@
 from django.db import connections
+from django.db.utils import ProgrammingError
 
 
 def fetch_data(queries, database="datasets"):
     """Fetch data from a database given a custom query."""
     count_query, main_query = queries
     with connections[database].chunked_cursor() as count_cursor:
-        count_cursor.execute(count_query)
-        count_results = count_cursor.fetchall()
+        try:
+            count_cursor.execute(count_query)
+            count_results = count_cursor.fetchall()
+        except ProgrammingError:
+            count_results = [[1]]
     with connections[database].chunked_cursor() as main_cursor:
-        main_cursor.execute(main_query)
-        first_row = main_cursor.fetchone()
-        columns = [col[0] for col in main_cursor.description]
-        results = [
-            dict(zip(columns, row)) for row in ([first_row] + main_cursor.fetchall())
-        ]
+        try:
+            main_cursor.execute(main_query)
+            first_row = main_cursor.fetchone()
+            columns = [col[0] for col in main_cursor.description]
+            results = [
+                dict(zip(columns, row)) for row in ([first_row] + main_cursor.fetchall())
+            ]
+        # Zip fails on empty dataset
+        except TypeError:
+            results = list()
+        # Something wrong with the SQL
+        except ProgrammingError as sql_err:
+            results = [
+                {
+                    "error": str(sql_err)
+                }
+            ]
         return (count_results[0][0], results)

--- a/data/tests.py
+++ b/data/tests.py
@@ -267,6 +267,32 @@ class TestFixtureData(TestCase):
         _, dat = fetch_data(queries, database="default")
         self.assertTrue('usd_disbursement_sum' in dat[0].keys())
 
+    def test_can_catch_sql_err(self):
+        OperationStep.objects.create(
+            operation=self.op,
+            step_id=2,
+            name="Select",
+            query_func="select",
+            query_kwargs="{ \"columns\": [ \"iso10\" ] }",
+            source_id=1
+        )
+        queries = self.op.build_query(1, 0, True)
+        _, dat = fetch_data(queries, database="default")
+        self.assertTrue("error" in list(dat[0].keys()))
+
+    def test_can_catch_zip_err(self):
+        OperationStep.objects.create(
+            operation=self.op,
+            step_id=2,
+            name="Filter",
+            query_func="filter",
+            query_kwargs='{"filters":[{"field":"year", "value":9999, "func":"ge"}]}',
+            source_id=1
+        )
+        queries = self.op.build_query(1, 0, False)
+        _, dat = fetch_data(queries, database="default")
+        self.assertEqual(len(dat), 0)
+
 
 class TestCommands(TestCase):
     def test_load_manual(self):


### PR DESCRIPTION
Really simple error handling with try/catch on TypeError and ProgrammingError. Handles the err thrown by bad SQL as well as the err thrown by zip on empty results. E.g. Operation 7 requests a missing column, and Operation 8 yields an empty dataset.

```
>>> from core.models import Operation
>>> op = Operation.objects.get(pk=7)
>>> op.query_table(1, 0, False)
(1, [{'error': 'column "iso10" does not exist\nLINE 1: ...ountry_name","di_id","year","income_group","iso3","iso10" FR...\n                                                             ^\nHINT:  Perhaps you meant to reference the column "historical_income_groupings.iso3".\n'}])
>>> op = Operation.objects.get(pk=8)
>>> op.query_table(1, 0, False)
(0, [])
```