### PR TITLE
Fix | remove django crontab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ WORKDIR /src
 # install dependencies
 RUN apt-get update
 RUN apt-get install -y net-tools
-# Uncomment the line below on dev environments to log cron output at /var/log/syslog
-# RUN apt-get install -y rsyslog
-RUN apt-get install -y cron
 RUN pip install -r requirements.txt
 
 # R dependencies
@@ -20,10 +17,4 @@ RUN apt-get install -y r-cran-reshape2
 
 ENV DJANGO_SETTINGS_MODULE=ddw_analyst_ui.docker_settings
 
-# Below lines are cron specific
-RUN python3 manage.py crontab remove
-RUN python3 manage.py crontab add
-# Below line 'exports' env to cron, otherwise cron will not run
-RUN printenv >> /etc/environment
-
-CMD export DOCKER_HOST_IP=$(route -n | awk '/UG[ \t]/{print $2}') && service cron restart && gunicorn -w 2 -b 0.0.0.0:80 -t 6000 --keep-alive 6000 ddw_analyst_ui.wsgi
+CMD export DOCKER_HOST_IP=$(route -n | awk '/UG[ \t]/{print $2}') && gunicorn -w 2 -b 0.0.0.0:80 -t 6000 --keep-alive 6000 ddw_analyst_ui.wsgi

--- a/README.md
+++ b/README.md
@@ -109,16 +109,11 @@ To create a test development DB, for local development (e.g. virtualenv steps be
 
         npm run dev
 
-### Django-crontab setup
-This is used to run cron jobs that run automated scripts that are added from the UI. You need to make sure cron is installed on the web docker container. If not, run `apt-get install cron`. This has been added to the Dockerfile so it should install this automatically for new deployments (container rebuilds)
+### Scheduled Events
 
-Export the env to cron by running this `printenv >> /etc/environment`. Then run `service cron restart` to restart cron.
+Configure a cronjob to run the `run-schedules.sh` script which in turn runs the command that checks for scheduled events every minute
 
-After, run `python3 manage.py crontab add` from the docker container or `docker-compose exec web python3 manage.py crontab add` from the host. This command should be run everytime there is a new cron entry added under settings file. Make sure to run this everytime a new entry is added to the CRONJOBS entry in settings. I advise running `python3 manage.py crontab remove` first to remove any entries that may no longer be wanted.
-
-You may confirm if the cron job has finally been added by running `docker-compose exec web python3 manage.py crontab show`. Running `docker-compose exec web python3 manage.py crontab remove` deletes all cron entries listed in settings.
-
-You may want to run `apt-get install nano` to install an editor to list all cron entries in case you want to inspect them from the container. This may be useful especially on staging or during development. It's not a requirement for the production environment. Similarly, in case you want to log the cron jobs (may be helpful in debugging), run `apt-get install -y rsyslog`. Syslog logs cron job executions here `/var/log/syslog`.
+    * * * * * /root/run-schedules.sh >/root/cron-logs.txt 2>&1
 
 ### End-To-End Testing
 

--- a/ddw_analyst_ui/settings.py
+++ b/ddw_analyst_ui/settings.py
@@ -41,7 +41,6 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django_crontab',
     'frontend',
     'core',
     'data',
@@ -184,10 +183,6 @@ WEBPACK_LOADER = {
         'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats.json'),
     }
 }
-
-CRONJOBS = [
-    ('* * * * *', 'django.core.management.call_command', ['run_schedules'])
-]
 
 QUERY_TABLES = [
     'fts_codenames', 'fts_privatemoney', 'fts_dacregion', 'fts_donorscountryid', 'fts_recipientcodename', 'fts_ngotype', 'fts_deliverychannels',

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,5 @@ soupsieve==1.9
 SQLAlchemy==1.3.2
 progressbar2==3.39.3
 django-webpack-loader>=0.6.0
-django-crontab==0.7.1
 
 boto3==1.14.21

--- a/run-schedules.sh
+++ b/run-schedules.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd /root/ddw-analyst-ui/
+
+/usr/local/bin/docker-compose exec -T web python3 manage.py run_schedules


### PR DESCRIPTION
Noticed the scheduled events had started failing again ... the last update restarted the `django-crontab` stuff, so I'm removing it... Updated the README with instructions on setting up a native cronjob.