### PR TITLE
Update deploy scripts to handle rabbit-mq slow start

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -35,7 +35,11 @@ function setup_rabbitmq {
       sleep 10
   done
 
-  docker-compose exec -T rabbitmq rabbitmqctl add_user admin ddw_analyst_ui
+  until docker-compose exec -T rabbitmq rabbitmqctl add_user admin ddw_analyst_ui; do
+      echo "Rabbit has not fully started - sleeping"
+      sleep 10
+  done
+
   docker-compose exec -T rabbitmq rabbitmqctl add_vhost myvhost
   docker-compose exec -T rabbitmq rabbitmqctl set_permissions -p myvhost admin ".*" ".*" ".*"
 }

--- a/deploy_script.sh
+++ b/deploy_script.sh
@@ -51,7 +51,11 @@ function setup_rabbitmq {
       sleep 10
   done
 
-  docker-compose exec -T rabbitmq rabbitmqctl add_user admin ddw_analyst_ui
+  until docker-compose exec -T rabbitmq rabbitmqctl add_user admin ddw_analyst_ui; do
+      echo "Rabbit has not fully started - sleeping"
+      sleep 10
+  done
+
   docker-compose exec -T rabbitmq rabbitmqctl add_vhost myvhost
   docker-compose exec -T rabbitmq rabbitmqctl set_permissions -p myvhost admin ".*" ".*" ".*"
 }


### PR DESCRIPTION
Rabbit-MQ is prone to a slow start, which prevents dependent configs from being executed during deployment. Hopefully this will fix that.