### PR TITLE
Feature | Order Steps

### DIFF
--- a/frontend/cypress/integration/queryBuilder.spec.js
+++ b/frontend/cypress/integration/queryBuilder.spec.js
@@ -156,7 +156,7 @@ describe('The Query Builder', () => {
     cy.get('[data-testid="qb-order-step-button"]').should('be.visible');
   });
 
-  it('navigates to reorder step view', () => {
+  it('navigates to reorder steps view and back to normal steps view', () => {
     // Visit query builder, type name and choose datasource
     cy.fillOperationForm('Test Dataset', 'Test Dataset', 'Financial Tracking Service');
 
@@ -176,5 +176,11 @@ describe('The Query Builder', () => {
 
     // Check that drag handles are visible
     cy.get('[data-testid="qb-drag-handle"]').should('be.visible');
+
+    // Navigate back to normal step view
+    cy.get('[data-testid="qb-order-step-button"]').click({ force: true });
+
+    // Check that drag handles do not exist
+    cy.get('[data-testid="qb-drag-handle"]').should('not.exist');
   });
 });

--- a/frontend/cypress/integration/queryBuilder.spec.js
+++ b/frontend/cypress/integration/queryBuilder.spec.js
@@ -133,4 +133,48 @@ describe('The Query Builder', () => {
   xit('previews a dataset', () => {
     // TODO: create test
   });
+
+  it('shows reorder step button', () => {
+    // Visit query builder, type name and choose datasource
+    cy.fillOperationForm('Test Dataset', 'Test Dataset', 'Financial Tracking Service');
+
+    cy.get('[data-testid="qb-add-step-button"]', { timeout: 10000 }).click();
+
+    // Create select query step
+    cy.createSelectStep();
+
+    // Fill create step form with 2 filters
+    cy.createFilterStep('amount{enter}', '{downarrow}boundary{downarrow}');
+
+    // Save and create step
+    cy.get('[data-testid="qb-step-preview-button"]', { timeout: 10000 }).click();
+
+    // Check that there is more than one step
+    cy.get('.list-group').children().should('have.length', 2);
+
+    // Check that reorder button is visible
+    cy.get('[data-testid="qb-order-step-button"]').should('be.visible');
+  });
+
+  it('navigates to reorder step view', () => {
+    // Visit query builder, type name and choose datasource
+    cy.fillOperationForm('Test Dataset', 'Test Dataset', 'Financial Tracking Service');
+
+    cy.get('[data-testid="qb-add-step-button"]', { timeout: 10000 }).click();
+
+    // Create select query step
+    cy.createSelectStep();
+
+    // Fill create step form with 2 filters
+    cy.createFilterStep('amount{enter}', '{downarrow}boundary{downarrow}');
+
+    // Save and create step
+    cy.get('[data-testid="qb-step-preview-button"]', { timeout: 10000 }).click();
+
+    // Navigate to reorder step view
+    cy.get('[data-testid="qb-order-step-button"]').click({ force: true });
+
+    // Check that drag handles are visible
+    cy.get('[data-testid="qb-drag-handle"]').should('be.visible');
+  });
 });

--- a/frontend/src/components/FilterItem/FilterItem.tsx
+++ b/frontend/src/components/FilterItem/FilterItem.tsx
@@ -38,7 +38,6 @@ export class FilterItem extends React.Component<FilterItemProps, FilterItemState
             search
             options={columns}
             onChange={this.onSelectColumn}
-            defaultValue={filter.get('field') as string}
             value={filter.get('field') as string}
             error={!!(errors && errors.get('field'))}
             disabled={!this.props.editable}
@@ -60,7 +59,6 @@ export class FilterItem extends React.Component<FilterItemProps, FilterItemState
             search
             options={operations}
             onChange={this.onSelectOperation}
-            defaultValue={this.props.filter.get('func') as string}
             value={filter.get('func') as string}
             error={!!(errors && errors.get('func'))}
             disabled={!this.props.editable}

--- a/frontend/src/components/OperationDataTable/OperationDataTable.tsx
+++ b/frontend/src/components/OperationDataTable/OperationDataTable.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { OperationDataMap } from '../../types/operations';
 import { OperationColumn } from '../../types/sources';
 import { api, formatString, localForageKeys } from '../../utils';
+import { BasicModal, ModalMessage } from '../BasicModal';
 
 interface OperationDataTableProps {
   list: List<OperationDataMap>;
@@ -48,8 +49,17 @@ export const OperationDataTable: FunctionComponent<OperationDataTableProps> = ({
 }) => {
   const [editableHeader, setEditableHeader] = useState('');
   const [columns, setColumns] = useState(props.columns);
+  const [modalMessage, setModalMessage] = useState('');
   const onToggleEditingHeader = (column?: OperationColumn): void => {
-    setEditableHeader(column ? column.column_name : '');
+    if (column && column.id) {
+      setEditableHeader(column.column_name);
+    } else if (column && !column.id) {
+      setModalMessage(
+        'Alias generation was not completed. To regenerate aliases, please save the dataset.',
+      );
+    } else {
+      setEditableHeader('');
+    }
   };
 
   const onEditColumnHeader = (event: KeyboardEvent<HTMLInputElement>, column: OperationColumn) => {
@@ -89,34 +99,43 @@ export const OperationDataTable: FunctionComponent<OperationDataTableProps> = ({
   };
 
   return (
-    <Table bordered responsive hover className="operation-data-table">
-      <thead>
-        <tr>
-          {columns.map((column) => (
-            <StyledTableHeader
-              key={column.column_name}
-              className="text-truncate"
-              onClick={() => onToggleEditingHeader(column)}
-            >
-              {editableHeaders && editableHeader === column.column_name ? (
-                <FormControl
-                  type="text"
-                  defaultValue={column.column_alias}
-                  onKeyPress={(event: KeyboardEvent<HTMLInputElement>) =>
-                    onEditColumnHeader(event, column)
-                  }
-                  autoFocus
-                  onBlur={() => onToggleEditingHeader()}
-                />
-              ) : (
-                formatString(column.column_alias)
-              )}
-            </StyledTableHeader>
-          ))}
-        </tr>
-      </thead>
-      <tbody data-testid="dataset-table-body">{renderTableRows(list, columns)}</tbody>
-    </Table>
+    <>
+      <Table bordered responsive hover className="operation-data-table">
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <StyledTableHeader
+                key={column.column_name}
+                className="text-truncate"
+                onClick={() => onToggleEditingHeader(column)}
+              >
+                {editableHeaders && editableHeader === column.column_name ? (
+                  <FormControl
+                    type="text"
+                    defaultValue={column.column_alias}
+                    onKeyPress={(event: KeyboardEvent<HTMLInputElement>) =>
+                      onEditColumnHeader(event, column)
+                    }
+                    autoFocus
+                    onBlur={() => onToggleEditingHeader()}
+                  />
+                ) : (
+                  formatString(column.column_alias)
+                )}
+              </StyledTableHeader>
+            ))}
+          </tr>
+        </thead>
+        <tbody data-testid="dataset-table-body">{renderTableRows(list, columns)}</tbody>
+      </Table>
+      <BasicModal
+        show={!!modalMessage}
+        onHide={() => setModalMessage('')}
+        title="Alias Editing Disabled"
+      >
+        {modalMessage ? <ModalMessage message={modalMessage} /> : null}
+      </BasicModal>
+    </>
   );
 };
 

--- a/frontend/src/components/OperationDataTableContainer/OperationDataTableContainer.tsx
+++ b/frontend/src/components/OperationDataTableContainer/OperationDataTableContainer.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent } from 'react';
 import { FetchOptions } from '../../types/api';
 import { OperationData, OperationMap } from '../../types/operations';
 import { OperationColumn, OperationColumnMap } from '../../types/sources';
+import { formatString } from '../../utils';
 import { OperationDataTable } from '../OperationDataTable';
 import { PaginationRow } from '../PaginationRow';
 
@@ -36,11 +37,16 @@ export const OperationDataTableContainer: FunctionComponent<OperationDataTableCo
       // make sure that the columns are in required order ... no using immutable as it messes up the order
       const _aliases = aliases.toJS() as OperationColumn[];
       columns = Object.keys(list[0])
-        .map<OperationColumn>((column) =>
-          column === 'error'
-            ? { id: 0, column_name: 'error', column_alias: 'Error' }
-            : (_aliases.find((alias) => alias.column_name === column) as OperationColumn),
-        )
+        .map<OperationColumn>((column) => {
+          if (column === 'error') {
+            return { id: 0, column_name: 'error', column_alias: 'Error' };
+          }
+
+          return (
+            _aliases.find((alias) => alias.column_name === column) ||
+            ({ column_name: column, column_alias: formatString(column) } as OperationColumn)
+          );
+        })
         .filter((column) => !!column); // remove undefined
     }
 

--- a/frontend/src/components/OperationForm/OperationForm.tsx
+++ b/frontend/src/components/OperationForm/OperationForm.tsx
@@ -24,11 +24,13 @@ interface OperationFormProps {
 
 const schema = Yup.object().shape({
   name: Yup.string().required('Name is required!'),
-  description: Yup.string().when('is_draft', {
-    is: true,
-    then: Yup.string(),
-    otherwise: Yup.string().required('Description is required'),
-  }),
+  description: Yup.string()
+    .when('is_draft', {
+      is: true,
+      then: Yup.string(),
+      otherwise: Yup.string().required('Description is required'),
+    })
+    .nullable(),
   is_draft: Yup.bool(),
 });
 

--- a/frontend/src/components/OperationStepView/OperationStepView.tsx
+++ b/frontend/src/components/OperationStepView/OperationStepView.tsx
@@ -68,6 +68,28 @@ export const OperationStepView: FunctionComponent<OperationStepProps> = ({ step,
             content_copy
           </StyledIcon>
         </StyledButton>
+        <StyledButton
+          className="pl-1"
+          title="Move Up"
+          variant="link"
+          size="sm"
+          data-testid="move-step-up"
+        >
+          <StyledIcon className="material-icons" data-testid="step-up-trigger">
+            expand_less
+          </StyledIcon>
+        </StyledButton>
+        <StyledButton
+          className="pl-1"
+          title="Move Down"
+          variant="link"
+          size="sm"
+          data-testid="move-step-down"
+        >
+          <StyledIcon className="material-icons" data-testid="step-down-trigger">
+            expand_more
+          </StyledIcon>
+        </StyledButton>
       </StyledActionsWrapper>
     );
   };

--- a/frontend/src/components/OperationStepView/OperationStepView.tsx
+++ b/frontend/src/components/OperationStepView/OperationStepView.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Badge, Button } from 'react-bootstrap';
+import { Badge, Button, Col } from 'react-bootstrap';
 import { Popup } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { OperationStepMap } from '../../types/operations';
@@ -74,15 +74,17 @@ export const OperationStepView: FunctionComponent<OperationStepProps> = ({ step,
 
   return (
     <React.Fragment>
-      <div>
-        <Badge variant="secondary">
-          {(step.get('query_func') as string).toUpperCase().split('_').join(' ')}
-        </Badge>
-      </div>
-      <StyledContentWrapper>
-        {step.get('name')}
-        {renderStepInfo(step)}
-      </StyledContentWrapper>
+      <Col className="pr-0" md={11}>
+        <div>
+          <Badge variant="secondary">
+            {(step.get('query_func') as string).toUpperCase().split('_').join(' ')}
+          </Badge>
+        </div>
+        <StyledContentWrapper>
+          {step.get('name')}
+          {renderStepInfo(step)}
+        </StyledContentWrapper>
+      </Col>
     </React.Fragment>
   );
 };

--- a/frontend/src/components/OperationStepView/OperationStepView.tsx
+++ b/frontend/src/components/OperationStepView/OperationStepView.tsx
@@ -68,28 +68,6 @@ export const OperationStepView: FunctionComponent<OperationStepProps> = ({ step,
             content_copy
           </StyledIcon>
         </StyledButton>
-        <StyledButton
-          className="pl-1"
-          title="Move Up"
-          variant="link"
-          size="sm"
-          data-testid="move-step-up"
-        >
-          <StyledIcon className="material-icons" data-testid="step-up-trigger">
-            expand_less
-          </StyledIcon>
-        </StyledButton>
-        <StyledButton
-          className="pl-1"
-          title="Move Down"
-          variant="link"
-          size="sm"
-          data-testid="move-step-down"
-        >
-          <StyledIcon className="material-icons" data-testid="step-down-trigger">
-            expand_more
-          </StyledIcon>
-        </StyledButton>
       </StyledActionsWrapper>
     );
   };

--- a/frontend/src/components/OperationStepView/OperationStepView.tsx
+++ b/frontend/src/components/OperationStepView/OperationStepView.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import { Badge } from 'react-bootstrap';
+import React, { FunctionComponent } from 'react';
+import { Badge, Button } from 'react-bootstrap';
 import { Popup } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { OperationStepMap } from '../../types/operations';
 
 interface OperationStepProps {
   step: OperationStepMap;
+  onDuplicateStep: (step?: OperationStepMap) => void;
 }
 
 const StyledPopContent = styled.div`
@@ -18,40 +19,70 @@ const StyledPopup = styled(Popup)`
 `;
 const StyledIcon = styled.i`
   font-size: 18px;
+  margin-right: 5px;
+`;
+const StyledButton = styled(Button)`
+  padding-top: 0 !important;
+  padding-right: 0 !important;
+  margin-top: 0;
+`;
+const StyledContentWrapper = styled.div`
+  position: relative;
+`;
+const StyledActionsWrapper = styled.div`
+  position: absolute;
+  display: inline-block;
+  right: 0;
+  margin-right: 1rem;
 `;
 
-export class OperationStepView extends React.Component<OperationStepProps> {
-  render() {
-    const { step } = this.props;
-
+export const OperationStepView: FunctionComponent<OperationStepProps> = ({ step, ...props }) => {
+  const onDuplicate = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    props.onDuplicateStep(step);
+  };
+  const renderStepInfo = (step: OperationStepMap) => {
     return (
-      <React.Fragment>
-        <div>
-          <Badge variant="secondary">
-            {(step.get('query_func') as string).toUpperCase().split('_').join(' ')}
-          </Badge>
-        </div>
-        <div>
-          {step.get('name')}
-          {this.renderStepInfo(step)}
-        </div>
-      </React.Fragment>
+      <StyledActionsWrapper>
+        {step.get('description') ? (
+          <StyledPopup
+            trigger={
+              <StyledIcon className="material-icons mt-1" data-testid="step-info-trigger">
+                info
+              </StyledIcon>
+            }
+            content={<StyledPopContent>{step.get('description')}</StyledPopContent>}
+            basic
+          />
+        ) : null}
+        <StyledButton
+          className="pl-1"
+          title="Duplicate"
+          variant="link"
+          size="sm"
+          data-testid="step-duplicate"
+          onClick={onDuplicate}
+        >
+          <StyledIcon className="material-icons" data-testid="step-duplicate-trigger">
+            content_copy
+          </StyledIcon>
+        </StyledButton>
+      </StyledActionsWrapper>
     );
-  }
+  };
 
-  private renderStepInfo(step: OperationStepMap) {
-    if (step.get('description')) {
-      return (
-        <StyledPopup
-          trigger={
-            <StyledIcon className="material-icons float-right mt-1" data-testid="step-info-trigger">
-              info
-            </StyledIcon>
-          }
-          content={<StyledPopContent>{step.get('description')}</StyledPopContent>}
-          basic
-        />
-      );
-    }
-  }
-}
+  return (
+    <React.Fragment>
+      <div>
+        <Badge variant="secondary">
+          {(step.get('query_func') as string).toUpperCase().split('_').join(' ')}
+        </Badge>
+      </div>
+      <StyledContentWrapper>
+        {step.get('name')}
+        {renderStepInfo(step)}
+      </StyledContentWrapper>
+    </React.Fragment>
+  );
+};

--- a/frontend/src/components/OperationStepView/OperationStepView.tsx
+++ b/frontend/src/components/OperationStepView/OperationStepView.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Badge, Button, Col } from 'react-bootstrap';
+import { Badge, Button } from 'react-bootstrap';
 import { Popup } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { OperationStepMap } from '../../types/operations';

--- a/frontend/src/components/OperationStepView/OperationStepView.tsx
+++ b/frontend/src/components/OperationStepView/OperationStepView.tsx
@@ -74,17 +74,15 @@ export const OperationStepView: FunctionComponent<OperationStepProps> = ({ step,
 
   return (
     <React.Fragment>
-      <Col className="pr-0" md={11}>
-        <div>
-          <Badge variant="secondary">
-            {(step.get('query_func') as string).toUpperCase().split('_').join(' ')}
-          </Badge>
-        </div>
-        <StyledContentWrapper>
-          {step.get('name')}
-          {renderStepInfo(step)}
-        </StyledContentWrapper>
-      </Col>
+      <div>
+        <Badge variant="secondary">
+          {(step.get('query_func') as string).toUpperCase().split('_').join(' ')}
+        </Badge>
+      </div>
+      <StyledContentWrapper>
+        {step.get('name')}
+        {renderStepInfo(step)}
+      </StyledContentWrapper>
     </React.Fragment>
   );
 };

--- a/frontend/src/components/OperationStepView/__tests__/OperationStepView.spec.tsx
+++ b/frontend/src/components/OperationStepView/__tests__/OperationStepView.spec.tsx
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Map } from 'immutable';
+import 'jest-styled-components';
+import React from 'react';
+import * as TestRenderer from 'react-test-renderer';
+import { OperationStep, OperationStepMap } from '../../../types/operations';
+import { OperationStepView } from '../OperationStepView';
+
+const step: Partial<OperationStep> = {
+  name: 'My Test Step',
+  updated_on: new Date('2020-01-02').toISOString(),
+  query_func: 'filter',
+  query_kwargs: 'kwargs',
+};
+
+const props = {
+  step: Map(step) as OperationStepMap,
+  onDuplicateStep: jest.fn(),
+};
+
+describe('OperationStep', () => {
+  afterEach(() => {
+    props.step = Map(step) as OperationStepMap;
+  });
+
+  test('renders correctly with the default props', () => {
+    const renderer = TestRenderer.create(<OperationStepView {...props} />).toJSON();
+
+    expect(renderer).toMatchSnapshot();
+  });
+
+  test('renders an info button when the provided step has a description', () => {
+    props.step = Map({ ...step, description: 'My Step Description' }) as OperationStepMap;
+    const renderer = TestRenderer.create(<OperationStepView {...props} />).toJSON();
+
+    expect(renderer).toMatchSnapshot();
+  });
+
+  test('renders a copy button that responds to clicks', () => {
+    render(<OperationStepView {...props} />);
+    const copyButton = screen.getByTestId('step-duplicate');
+    fireEvent.click(copyButton);
+
+    expect(props.onDuplicateStep).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/OperationStepView/__tests__/__snapshots__/OperationStepView.spec.tsx.snap
+++ b/frontend/src/components/OperationStepView/__tests__/__snapshots__/OperationStepView.spec.tsx.snap
@@ -1,0 +1,128 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OperationStep renders an info button when the provided step has a description 1`] = `
+Array [
+  <div>
+    <span
+      className="badge badge-secondary"
+    >
+      FILTER
+    </span>
+  </div>,
+  .c2 {
+  font-size: 18px;
+  margin-right: 5px;
+}
+
+.c3 {
+  padding-top: 0 !important;
+  padding-right: 0 !important;
+  margin-top: 0;
+}
+
+.c0 {
+  position: relative;
+}
+
+.c1 {
+  position: absolute;
+  display: inline-block;
+  right: 0;
+  margin-right: 1rem;
+}
+
+<div
+    className="c0"
+  >
+    My Test Step
+    <div
+      className="c1"
+    >
+      <i
+        className="c2 material-icons mt-1"
+        data-testid="step-info-trigger"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        info
+      </i>
+      <button
+        className="c3 pl-1 btn btn-link btn-sm"
+        data-testid="step-duplicate"
+        disabled={false}
+        onClick={[Function]}
+        title="Duplicate"
+        type="button"
+      >
+        <i
+          className="c2 material-icons"
+          data-testid="step-duplicate-trigger"
+        >
+          content_copy
+        </i>
+      </button>
+    </div>
+  </div>,
+]
+`;
+
+exports[`OperationStep renders correctly with the default props 1`] = `
+Array [
+  <div>
+    <span
+      className="badge badge-secondary"
+    >
+      FILTER
+    </span>
+  </div>,
+  .c3 {
+  font-size: 18px;
+  margin-right: 5px;
+}
+
+.c2 {
+  padding-top: 0 !important;
+  padding-right: 0 !important;
+  margin-top: 0;
+}
+
+.c0 {
+  position: relative;
+}
+
+.c1 {
+  position: absolute;
+  display: inline-block;
+  right: 0;
+  margin-right: 1rem;
+}
+
+<div
+    className="c0"
+  >
+    My Test Step
+    <div
+      className="c1"
+    >
+      <button
+        className="c2 pl-1 btn btn-link btn-sm"
+        data-testid="step-duplicate"
+        disabled={false}
+        onClick={[Function]}
+        title="Duplicate"
+        type="button"
+      >
+        <i
+          className="c3 material-icons"
+          data-testid="step-duplicate-trigger"
+        >
+          content_copy
+        </i>
+      </button>
+    </div>
+  </div>,
+]
+`;

--- a/frontend/src/components/OperationSteps/OperationSteps.tsx
+++ b/frontend/src/components/OperationSteps/OperationSteps.tsx
@@ -129,7 +129,6 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
 
   const onUpdateSteps = (orderedSteps: string) => {
     if (isOrderingSteps) {
-      console.log('Ordaring');
       const orderedStepsArray: string[] = JSON.parse(orderedSteps);
       const unorderedStepsArray = steps.valueSeq().toArray();
       orderedStepsArray.forEach((orderedStep, orderedIndex) => {

--- a/frontend/src/components/OperationSteps/OperationSteps.tsx
+++ b/frontend/src/components/OperationSteps/OperationSteps.tsx
@@ -35,6 +35,7 @@ export const StyledListItem = styled(ListGroup.Item)`
   cursor: ${(props) => (props.disabled ? 'default' : 'pointer')};
   border-color: ${(props) => (props.active ? '#737373 !important' : 'default')};
   background-color: ${(props) => (props.active ? '#EEEEEE' : '#FFFFFF')};
+  user-select: none;
 `;
 export const StyledStepContainer = styled.div`
   border-bottom: 1px solid rgba(0, 0, 0, 0.125);
@@ -182,6 +183,7 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
           onClick={handleStepOrderClick}
           disabled={!!activeStep || props.disabled}
           data-testid="qb-add-step-button"
+          hidden={steps.size <= 1}
         >
           {!isOrderingSteps ? (
             <i className="material-icons mr-1">reorder</i>

--- a/frontend/src/components/OperationSteps/OperationSteps.tsx
+++ b/frontend/src/components/OperationSteps/OperationSteps.tsx
@@ -23,27 +23,13 @@ interface OperationStepsProps {
   onDuplicateStep: (step?: OperationStepMap) => void;
 }
 
-const StyledButton = styled(Button)`
-  padding-top: 0 !important;
-  padding-right: 0 !important;
-  margin-top: 0;
-`;
-
 const StyledListItem = styled(ListGroup.Item)`
   cursor: ${(props) => (props.disabled ? 'default' : 'pointer')};
   border-color: ${(props) => (props.active ? '#737373 !important' : 'default')};
   background-color: ${(props) => (props.active ? '#EEEEEE' : '#FFFFFF')};
 `;
-
-const StyledButtonWrapper = styled.div`
-  display: none;
-`;
 const StyledStepContainer = styled.div`
   border-bottom: 1px solid rgba(0, 0, 0, 0.125);
-  &:hover {
-    ${StyledButtonWrapper} {
-      display: inline-flex !important;
-    }
 `;
 
 const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
@@ -67,19 +53,8 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
                     disabled={(activeStep && !isActiveStep) || props.disabled}
                     active={isActiveStep}
                   >
-                    <OperationStep step={step} />
+                    <OperationStep step={step} onDuplicateStep={props.onDuplicateStep} />
                   </StyledListItem>
-                  <StyledButtonWrapper>
-                    <StyledButton
-                      title="Duplicate"
-                      variant="link"
-                      size="sm"
-                      data-testid="step-duplicate"
-                      onClick={() => props.onDuplicateStep(step)}
-                    >
-                      <i className="material-icons">content_copy</i>
-                    </StyledButton>
-                  </StyledButtonWrapper>
                 </StyledStepContainer>
               );
             })}

--- a/frontend/src/components/OperationSteps/OperationSteps.tsx
+++ b/frontend/src/components/OperationSteps/OperationSteps.tsx
@@ -187,11 +187,7 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
           data-placement="right"
           title="Toggle Sort Steps"
         >
-          {!isOrderingSteps ? (
-            <i className="material-icons">reorder</i>
-          ) : (
-            <i className="material-icons">view_list</i>
-          )}
+          <i className="material-icons">reorder</i>
         </Button>
       </div>
 

--- a/frontend/src/components/OperationSteps/OperationSteps.tsx
+++ b/frontend/src/components/OperationSteps/OperationSteps.tsx
@@ -41,26 +41,18 @@ const StyledStepContainer = styled.div`
 `;
 
 const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
-  const { activeSource, activeStep, editable, isFetchingSources, sources, steps } = props;
+  const { activeSource, activeStep, editable, steps } = props;
   const [isOrderingSteps, setIsOrderingSteps] = useState(false);
   const [createdSteps, setCreatedSteps] = useState<Step[]>([]);
-
-  useEffect(() => {
-    if (props.activeSource && props.sources && props.sources.count() === 0) {
-      fetchSources();
-    }
-  });
+  const sources = useSources({ limit: 200, offset: 0 });
 
   useEffect(() => {
     setCreatedSteps(
-      steps
-        .valueSeq()
-        .toArray()
-        .map((step) => ({
-          step_id: step.get('step_id') as string,
-          name: step.get('name') as string,
-          query_func: step.get('query_func') as string,
-        })),
+      steps.toArray().map((step) => ({
+        step_id: step.get('step_id') as string,
+        name: step.get('name') as string,
+        query_func: step.get('query_func') as string,
+      })),
     );
   }, [steps]);
 
@@ -141,12 +133,12 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
         unorderedStepsArray.forEach((unorderedStep) => {
           if (unorderedStep.get('step_id') === orderedStep) {
             const updatedStep = unorderedStep.update('step_id', () => orderedIndex + 1);
+            props.onReorderSteps(updatedStep);
             result.push({
               step_id: unorderedStep.get('step_id') as string,
               name: unorderedStep.get('name') as string,
               query_func: unorderedStep.get('query_func') as string,
             });
-            props.onReorderSteps(updatedStep);
           }
         });
       });

--- a/frontend/src/components/OperationSteps/OperationSteps.tsx
+++ b/frontend/src/components/OperationSteps/OperationSteps.tsx
@@ -125,16 +125,19 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
   };
 
   const onUpdateSteps = (orderedSteps: string) => {
-    const orderedStepsArray: string[] = JSON.parse(orderedSteps);
-    const unorderedStepsArray = steps.valueSeq().toArray();
-    orderedStepsArray.forEach((orderedStep, orderedIndex) => {
-      unorderedStepsArray.forEach((unorderedStep) => {
-        if (unorderedStep.get('step_id') === orderedStep) {
-          const updatedStep = unorderedStep.update('step_id', () => orderedIndex + 1);
-          props.onReorderSteps(updatedStep);
-        }
+    if (isOrderingSteps) {
+      console.log('Ordering');
+      const orderedStepsArray: string[] = JSON.parse(orderedSteps);
+      const unorderedStepsArray = steps.valueSeq().toArray();
+      orderedStepsArray.forEach((orderedStep, orderedIndex) => {
+        unorderedStepsArray.forEach((unorderedStep) => {
+          if (unorderedStep.get('step_id') === orderedStep) {
+            const updatedStep = unorderedStep.update('step_id', () => orderedIndex + 1);
+            props.onReorderSteps(updatedStep);
+          }
+        });
       });
-    });
+    }
   };
 
   return (

--- a/frontend/src/components/OperationSteps/OperationSteps.tsx
+++ b/frontend/src/components/OperationSteps/OperationSteps.tsx
@@ -31,12 +31,12 @@ export interface Step {
   step_id: string | number;
 }
 
-const StyledListItem = styled(ListGroup.Item)`
+export const StyledListItem = styled(ListGroup.Item)`
   cursor: ${(props) => (props.disabled ? 'default' : 'pointer')};
   border-color: ${(props) => (props.active ? '#737373 !important' : 'default')};
   background-color: ${(props) => (props.active ? '#EEEEEE' : '#FFFFFF')};
 `;
-const StyledStepContainer = styled.div`
+export const StyledStepContainer = styled.div`
   border-bottom: 1px solid rgba(0, 0, 0, 0.125);
 `;
 
@@ -171,7 +171,6 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
           size="sm"
           onClick={onAddStep}
           disabled={!!activeStep || props.disabled}
-          hidden={isOrderingSteps}
           data-testid="qb-add-step-button"
         >
           <i className="material-icons mr-1">add</i>
@@ -194,7 +193,15 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
       </div>
 
       {isOrderingSteps ? (
-        <OperationStepsOrder createdSteps={createdSteps} onUpdateSteps={onUpdateSteps} />
+        <OperationStepsOrder
+          createdSteps={createdSteps}
+          onUpdateSteps={onUpdateSteps}
+          steps={steps}
+          activeStep={activeStep}
+          onClickStep={props.onClickStep}
+          onDuplicateStep={props.onDuplicateStep}
+          disabled={props.disabled}
+        />
       ) : (
         renderOperationSteps(steps, activeStep)
       )}

--- a/frontend/src/components/OperationSteps/OperationSteps.tsx
+++ b/frontend/src/components/OperationSteps/OperationSteps.tsx
@@ -126,25 +126,14 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
 
   const onUpdateSteps = (orderedSteps: string) => {
     const orderedStepsArray: string[] = JSON.parse(orderedSteps);
-    setCreatedSteps(() => {
-      const result: Step[] = [];
-      const unorderedStepsArray = steps.valueSeq().toArray();
-
-      orderedStepsArray.forEach((orderedStep, orderedIndex) => {
-        unorderedStepsArray.forEach((unorderedStep) => {
-          if (unorderedStep.get('step_id') === orderedStep) {
-            const updatedStep = unorderedStep.update('step_id', () => orderedIndex + 1);
-            props.onReorderSteps(updatedStep);
-            result.push({
-              step_id: unorderedStep.get('step_id') as string,
-              name: unorderedStep.get('name') as string,
-              query_func: unorderedStep.get('query_func') as string,
-            });
-          }
-        });
+    const unorderedStepsArray = steps.valueSeq().toArray();
+    orderedStepsArray.forEach((orderedStep, orderedIndex) => {
+      unorderedStepsArray.forEach((unorderedStep) => {
+        if (unorderedStep.get('step_id') === orderedStep) {
+          const updatedStep = unorderedStep.update('step_id', () => orderedIndex + 1);
+          props.onReorderSteps(updatedStep);
+        }
       });
-
-      return orderedStepsArray.length > 0 ? result : createdSteps;
     });
   };
 

--- a/frontend/src/components/OperationSteps/OperationSteps.tsx
+++ b/frontend/src/components/OperationSteps/OperationSteps.tsx
@@ -49,11 +49,14 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
 
   useEffect(() => {
     setCreatedSteps(
-      steps.toArray().map((step) => ({
-        step_id: step.get('step_id') as string,
-        name: step.get('name') as string,
-        query_func: step.get('query_func') as string,
-      })),
+      steps
+        .sort(sortSteps)
+        .toArray()
+        .map((step) => ({
+          step_id: step.get('step_id') as string,
+          name: step.get('name') as string,
+          query_func: step.get('query_func') as string,
+        })),
     );
   }, [steps]);
 
@@ -126,7 +129,7 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
 
   const onUpdateSteps = (orderedSteps: string) => {
     if (isOrderingSteps) {
-      console.log('Ordering');
+      console.log('Ordaring');
       const orderedStepsArray: string[] = JSON.parse(orderedSteps);
       const unorderedStepsArray = steps.valueSeq().toArray();
       orderedStepsArray.forEach((orderedStep, orderedIndex) => {

--- a/frontend/src/components/OperationSteps/OperationSteps.tsx
+++ b/frontend/src/components/OperationSteps/OperationSteps.tsx
@@ -48,6 +48,10 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
   const sources = useSources({ limit: 200, offset: 0 });
 
   useEffect(() => {
+    (window as any).$('[data-toggle="sort-tooltip"]').tooltip(); // eslint-disable-line
+  }, []);
+
+  useEffect(() => {
     setCreatedSteps(
       steps
         .sort(sortSteps)
@@ -172,13 +176,16 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
           Add Step
         </Button>
         <Button
-          variant={isOrderingSteps ? 'warning' : 'dark'}
+          variant={isOrderingSteps ? 'dark' : 'danger'}
           size="sm"
           onClick={handleStepOrderClick}
           disabled={!!activeStep || props.disabled}
           data-testid="qb-order-step-button"
           hidden={steps.size <= 1}
           className="pl-2 pr-2"
+          data-toggle="sort-tooltip"
+          data-placement="right"
+          title="Toggle Sort Steps"
         >
           {!isOrderingSteps ? (
             <i className="material-icons">reorder</i>

--- a/frontend/src/components/OperationSteps/OperationSteps.tsx
+++ b/frontend/src/components/OperationSteps/OperationSteps.tsx
@@ -172,19 +172,19 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
           Add Step
         </Button>
         <Button
-          variant="danger"
+          variant={isOrderingSteps ? 'warning' : 'dark'}
           size="sm"
           onClick={handleStepOrderClick}
           disabled={!!activeStep || props.disabled}
           data-testid="qb-order-step-button"
           hidden={steps.size <= 1}
+          className="pl-2 pr-2"
         >
           {!isOrderingSteps ? (
-            <i className="material-icons mr-1">reorder</i>
+            <i className="material-icons">reorder</i>
           ) : (
-            <i className="material-icons mr-1">view_list</i>
+            <i className="material-icons">view_list</i>
           )}
-          {!isOrderingSteps ? 'Order Steps' : 'View Steps'}
         </Button>
       </div>
 

--- a/frontend/src/components/OperationSteps/OperationSteps.tsx
+++ b/frontend/src/components/OperationSteps/OperationSteps.tsx
@@ -171,7 +171,7 @@ const OperationSteps: FunctionComponent<OperationStepsProps> = (props) => {
           size="sm"
           onClick={handleStepOrderClick}
           disabled={!!activeStep || props.disabled}
-          data-testid="qb-add-step-button"
+          data-testid="qb-order-step-button"
           hidden={steps.size <= 1}
         >
           {!isOrderingSteps ? (

--- a/frontend/src/components/OperationStepsOrder/DragStepOverlayItem.tsx
+++ b/frontend/src/components/OperationStepsOrder/DragStepOverlayItem.tsx
@@ -1,0 +1,30 @@
+import React, { forwardRef } from 'react';
+import { Col, Row } from 'react-bootstrap';
+import { OperationStepMap } from '../../types/operations';
+import { StyledListItem, StyledStepContainer } from '../OperationSteps';
+import OperationStepView from '../OperationStepView';
+
+interface SortableStepProps {
+  id: string;
+  step: OperationStepMap;
+  onDuplicateStep: (step?: OperationStepMap) => void;
+}
+
+const DragStepOverlayItem = forwardRef<HTMLInputElement, SortableStepProps>((props, ref) => (
+  <StyledStepContainer ref={ref} id={props.id}>
+    <StyledListItem data-testid="qb-step-wrapper" className="py-2" active={false}>
+      <Row>
+        <Col md={0.5}>
+          <i className="pl-1 material-icons mr-1">drag_indicator</i>
+        </Col>
+        <Col className="w-90" md={11}>
+          <OperationStepView step={props.step} onDuplicateStep={props.onDuplicateStep} />
+        </Col>
+      </Row>
+    </StyledListItem>
+  </StyledStepContainer>
+));
+
+DragStepOverlayItem.displayName = 'DragStepOverlayItem';
+
+export { DragStepOverlayItem };

--- a/frontend/src/components/OperationStepsOrder/DragStepOverlayItem.tsx
+++ b/frontend/src/components/OperationStepsOrder/DragStepOverlayItem.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from 'react';
 import { Col, Row } from 'react-bootstrap';
+import styled from 'styled-components';
 import { OperationStepMap } from '../../types/operations';
 import { StyledListItem, StyledStepContainer } from '../OperationSteps';
 import OperationStepView from '../OperationStepView';
@@ -10,12 +11,16 @@ interface SortableStepProps {
   onDuplicateStep: (step?: OperationStepMap) => void;
 }
 
+const StyledIcon = styled.i`
+  font-size: 18px;
+`;
+
 const DragStepOverlayItem = forwardRef<HTMLInputElement, SortableStepProps>((props, ref) => (
   <StyledStepContainer ref={ref} id={props.id}>
     <StyledListItem data-testid="qb-step-wrapper" className="py-2" active={false}>
       <Row>
-        <Col md={0.5}>
-          <i className="pl-1 material-icons mr-1">drag_indicator</i>
+        <Col md={0.5} className="mt-auto mb-auto">
+          <StyledIcon className="material-icons">drag_indicator</StyledIcon>
         </Col>
         <Col className="w-90" md={11}>
           <OperationStepView step={props.step} onDuplicateStep={props.onDuplicateStep} />

--- a/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
+++ b/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
@@ -16,13 +16,12 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { Alert, ListGroup, Row } from 'react-bootstrap';
-import styled from 'styled-components';
-import { Step } from '../OperationSteps';
+import { ListGroup, Row } from 'react-bootstrap';
 import { OperationStepMap } from '../../types/operations';
 import { List } from 'immutable';
 import { SortableStep } from './SortableStep';
-import { DragOverlayItem } from '../SelectColumnOrder/DragOverlayItem';
+import { DragStepOverlayItem } from './DragStepOverlayItem';
+import { Step } from '../OperationSteps';
 
 interface StepsOrderProps {
   steps: List<OperationStepMap>;
@@ -33,13 +32,6 @@ interface StepsOrderProps {
   onUpdateSteps?: (options: string) => void;
   onClickStep: (step?: OperationStepMap) => void;
 }
-
-const StyledSpan = styled.span`
-  top: -6px;
-  position: relative;
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-`;
 
 const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
   createdSteps,
@@ -52,6 +44,7 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
 }) => {
   const [orderedSteps, setOrderedSteps] = useState(createdSteps?.map((step) => step.step_id));
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [dragStep, setDragStep] = useState<OperationStepMap>(activeStep as OperationStepMap);
 
   useEffect(() => {
     if (onUpdateSteps) {
@@ -68,6 +61,7 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
     const { active } = event;
 
     setActiveId(active.id);
+    setDragStep(getDragStep(active.id));
   };
 
   const handleDragEnd = ({ active, over }: DragEndEvent) => {
@@ -84,6 +78,12 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
     }
 
     setActiveId(null);
+  };
+
+  const getDragStep = (id: string) => {
+    const step = steps.find((step) => `${step.get('step_id')}` === id);
+
+    return step as OperationStepMap;
   };
 
   return (
@@ -124,7 +124,15 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
             </ListGroup>
           </Row>
         </SortableContext>
-        <DragOverlay>{activeId ? <DragOverlayItem id={activeId} /> : null}</DragOverlay>
+        <DragOverlay>
+          {activeId ? (
+            <DragStepOverlayItem
+              id={activeId}
+              onDuplicateStep={onDuplicateStep}
+              step={dragStep}
+            ></DragStepOverlayItem>
+          ) : null}
+        </DragOverlay>
       </DndContext>
     </>
   );

--- a/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
+++ b/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
@@ -1,0 +1,106 @@
+import React, { FunctionComponent, useEffect, useState } from 'react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { SelectColumn } from '../SelectColumn/SelectColumn';
+import { Alert } from 'react-bootstrap';
+import styled from 'styled-components';
+import { Step } from '../OperationSteps';
+
+interface SelectColumnOrderProps {
+  createdSteps: Step[];
+  onUpdateColumns?: (options: string) => void;
+}
+
+const StyledSpan = styled.span`
+  top: -6px;
+  position: relative;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+`;
+
+const StyledWrapper = styled.div`
+  max-height: 400px;
+  overflow-y: scroll;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const OperationStepsOrder: FunctionComponent<SelectColumnOrderProps> = ({
+  createdSteps,
+  onUpdateColumns,
+}) => {
+  const [orderedColumns, setOrderedColumns] = useState(createdSteps?.map((column) => column.name));
+
+  useEffect(() => {
+    if (onUpdateColumns) {
+      onUpdateColumns(JSON.stringify(orderedColumns));
+    }
+  }, [orderedColumns]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (over && active.id !== over.id) {
+      setOrderedColumns(() => {
+        const columnNames = createdSteps.map((step) => step.name);
+        const activeColumn = createdSteps.find(
+          (step) => `${step.name} - ${step.query_func}` === active.id,
+        );
+        const overColumn = createdSteps.find(
+          (step) => `${step.name} - ${step.query_func}` === over.id,
+        );
+        const oldIndex = columnNames.indexOf(activeColumn ? activeColumn.name : '');
+        const newIndex = columnNames.indexOf(overColumn ? overColumn.name : '');
+
+        return arrayMove(columnNames, oldIndex, newIndex);
+      });
+    }
+  };
+
+  return (
+    <>
+      <Alert variant="dark" className="mt-3 p-3 w-50">
+        <i className="material-icons">info</i>{' '}
+        <StyledSpan className="d-inline-flex">Drag & drop columns to desired position</StyledSpan>
+      </Alert>
+      <StyledWrapper>
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext
+            items={
+              createdSteps ? createdSteps.map((step) => `${step.name} - ${step.query_func}`) : []
+            }
+            strategy={verticalListSortingStrategy}
+          >
+            {createdSteps && createdSteps.length > 0 ? (
+              createdSteps.map((step) => (
+                <SelectColumn key={step.step_id} id={`${step.name} - ${step.query_func}`} />
+              ))
+            ) : (
+              <div data-testid="qb-select-no-column-message">No columns selected</div>
+            )}
+          </SortableContext>
+        </DndContext>
+      </StyledWrapper>
+    </>
+  );
+};
+
+export { OperationStepsOrder };

--- a/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
+++ b/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
@@ -22,6 +22,7 @@ import { List } from 'immutable';
 import { SortableStep } from './SortableStep';
 import { DragStepOverlayItem } from './DragStepOverlayItem';
 import { Step } from '../OperationSteps';
+import { sort } from '../../utils';
 
 interface StepsOrderProps {
   steps: List<OperationStepMap>;
@@ -86,6 +87,13 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
     return step as OperationStepMap;
   };
 
+  const sortSteps = (stepA: Step, stepB: Step): number => {
+    const valueA = stepA.step_id as number;
+    const valueB = stepB.step_id as number;
+
+    return sort(valueA, valueB);
+  };
+
   return (
     <>
       <DndContext
@@ -103,18 +111,22 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
           <Row>
             <ListGroup variant="flush" className="w-100">
               {createdSteps && createdSteps.length > 0 ? (
-                createdSteps.map((step, index) => {
+                createdSteps.sort(sortSteps).map((step, index) => {
+                  const stepMap = steps.find(
+                    (stepMapItem) => stepMapItem.get('step_id') === step.step_id,
+                  ) as OperationStepMap;
+
                   return (
                     <SortableStep
                       key={index}
                       id={`${step.step_id}`}
-                      steps={steps}
                       step={step}
                       activeStep={activeStep}
                       isActiveStep={activeStep && activeStep.get('step_id') === step.step_id}
                       onClickStep={onClickStep}
                       onDuplicateStep={onDuplicateStep}
                       disabled={disabled}
+                      stepMap={stepMap}
                     />
                   );
                 })

--- a/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
+++ b/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
@@ -94,7 +94,9 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
     <>
       <Alert variant="dark" className="mt-3 p-3 w-50">
         <i className="material-icons">info</i>{' '}
-        <StyledSpan className="d-inline-flex">Drag & drop steps to desired position</StyledSpan>
+        <StyledSpan className="d-inline-flex">
+          Drag & drop steps to desired position with the drag icon on the left of each step.
+        </StyledSpan>
       </Alert>
       <DndContext
         sensors={sensors}

--- a/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
+++ b/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
@@ -74,12 +74,8 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
     if (over && active.id !== over.id) {
       setOrderedSteps(() => {
         const stepIds = steps.toArray().map((step) => step.get('step_id') as string);
-        const activeStep = steps.find(
-          (step) => `${step.get('name')} - ${step.get('query_func')}` === active.id,
-        );
-        const overStep = steps.find(
-          (step) => `${step.get('name')} - ${step.get('query_func')}` === over.id,
-        );
+        const activeStep = steps.find((step) => `${step.get('step_id')}` === active.id);
+        const overStep = steps.find((step) => `${step.get('step_id')}` === over.id);
         const oldIndex = stepIds.indexOf(activeStep ? (activeStep.get('step_id') as string) : '');
         const newIndex = stepIds.indexOf(overStep ? (overStep.get('step_id') as string) : '');
 
@@ -117,7 +113,7 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
                   return (
                     <SortableStep
                       key={index}
-                      id={`${step.name} - ${step.query_func}`}
+                      id={`${step.step_id}`}
                       steps={steps}
                       step={step}
                       activeStep={activeStep}

--- a/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
+++ b/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
@@ -19,9 +19,9 @@ import { Alert } from 'react-bootstrap';
 import styled from 'styled-components';
 import { Step } from '../OperationSteps';
 
-interface SelectColumnOrderProps {
+interface StepsOrderProps {
   createdSteps: Step[];
-  onUpdateColumns?: (options: string) => void;
+  onUpdateSteps?: (options: string) => void;
 }
 
 const StyledSpan = styled.span`
@@ -40,17 +40,17 @@ const StyledWrapper = styled.div`
   }
 `;
 
-const OperationStepsOrder: FunctionComponent<SelectColumnOrderProps> = ({
+const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
   createdSteps,
-  onUpdateColumns,
+  onUpdateSteps,
 }) => {
-  const [orderedColumns, setOrderedColumns] = useState(createdSteps?.map((column) => column.name));
+  const [orderedSteps, setOrderedSteps] = useState(createdSteps?.map((step) => step.step_id));
 
   useEffect(() => {
-    if (onUpdateColumns) {
-      onUpdateColumns(JSON.stringify(orderedColumns));
+    if (onUpdateSteps) {
+      onUpdateSteps(JSON.stringify(orderedSteps));
     }
-  }, [orderedColumns]);
+  }, [orderedSteps]);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -59,18 +59,18 @@ const OperationStepsOrder: FunctionComponent<SelectColumnOrderProps> = ({
 
   const handleDragEnd = ({ active, over }: DragEndEvent) => {
     if (over && active.id !== over.id) {
-      setOrderedColumns(() => {
-        const columnNames = createdSteps.map((step) => step.name);
-        const activeColumn = createdSteps.find(
+      setOrderedSteps(() => {
+        const stepIds = createdSteps.map((step) => step.step_id as string);
+        const activeStep = createdSteps.find(
           (step) => `${step.name} - ${step.query_func}` === active.id,
         );
-        const overColumn = createdSteps.find(
+        const overStep = createdSteps.find(
           (step) => `${step.name} - ${step.query_func}` === over.id,
         );
-        const oldIndex = columnNames.indexOf(activeColumn ? activeColumn.name : '');
-        const newIndex = columnNames.indexOf(overColumn ? overColumn.name : '');
+        const oldIndex = stepIds.indexOf(activeStep ? (activeStep.step_id as string) : '');
+        const newIndex = stepIds.indexOf(overStep ? (overStep.step_id as string) : '');
 
-        return arrayMove(columnNames, oldIndex, newIndex);
+        return arrayMove(stepIds, oldIndex, newIndex);
       });
     }
   };
@@ -79,7 +79,7 @@ const OperationStepsOrder: FunctionComponent<SelectColumnOrderProps> = ({
     <>
       <Alert variant="dark" className="mt-3 p-3 w-50">
         <i className="material-icons">info</i>{' '}
-        <StyledSpan className="d-inline-flex">Drag & drop columns to desired position</StyledSpan>
+        <StyledSpan className="d-inline-flex">Drag & drop steps to desired position</StyledSpan>
       </Alert>
       <StyledWrapper>
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
@@ -94,7 +94,7 @@ const OperationStepsOrder: FunctionComponent<SelectColumnOrderProps> = ({
                 <SelectColumn key={step.step_id} id={`${step.name} - ${step.query_func}`} />
               ))
             ) : (
-              <div data-testid="qb-select-no-column-message">No columns selected</div>
+              <div data-testid="qb-select-no-column-message">No steps selected</div>
             )}
           </SortableContext>
         </DndContext>

--- a/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
+++ b/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
@@ -42,12 +42,12 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
   onDuplicateStep,
   disabled,
 }) => {
-  const [orderedSteps, setOrderedSteps] = useState(createdSteps?.map((step) => step.step_id));
+  const [orderedSteps, setOrderedSteps] = useState<string[]>();
   const [activeId, setActiveId] = useState<string | null>(null);
   const [dragStep, setDragStep] = useState<OperationStepMap>(activeStep as OperationStepMap);
 
   useEffect(() => {
-    if (onUpdateSteps) {
+    if (onUpdateSteps && orderedSteps) {
       onUpdateSteps(JSON.stringify(orderedSteps));
     }
   }, [orderedSteps]);

--- a/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
+++ b/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
@@ -14,10 +14,10 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { SelectColumn } from '../SelectColumn/SelectColumn';
 import { Alert } from 'react-bootstrap';
 import styled from 'styled-components';
 import { Step } from '../OperationSteps';
+import { SortableItem } from '../SelectColumnOrder/SortableItem';
 
 interface StepsOrderProps {
   createdSteps: Step[];
@@ -91,7 +91,7 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
           >
             {createdSteps && createdSteps.length > 0 ? (
               createdSteps.map((step) => (
-                <SelectColumn key={step.step_id} id={`${step.name} - ${step.query_func}`} />
+                <SortableItem key={step.step_id} id={`${step.name} - ${step.query_func}`} />
               ))
             ) : (
               <div data-testid="qb-select-no-column-message">No steps selected</div>

--- a/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
+++ b/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
@@ -7,6 +7,8 @@ import {
   useSensor,
   useSensors,
   DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
 } from '@dnd-kit/core';
 import {
   arrayMove,
@@ -14,14 +16,22 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { Alert } from 'react-bootstrap';
+import { Alert, ListGroup, Row } from 'react-bootstrap';
 import styled from 'styled-components';
 import { Step } from '../OperationSteps';
-import { SortableItem } from '../SelectColumnOrder/SortableItem';
+import { OperationStepMap } from '../../types/operations';
+import { List } from 'immutable';
+import { SortableStep } from './SortableStep';
+import { DragOverlayItem } from '../SelectColumnOrder/DragOverlayItem';
 
 interface StepsOrderProps {
+  steps: List<OperationStepMap>;
+  activeStep?: OperationStepMap;
   createdSteps: Step[];
+  disabled?: boolean;
+  onDuplicateStep: (step?: OperationStepMap) => void;
   onUpdateSteps?: (options: string) => void;
+  onClickStep: (step?: OperationStepMap) => void;
 }
 
 const StyledSpan = styled.span`
@@ -31,20 +41,17 @@ const StyledSpan = styled.span`
   scrollbar-width: none;
 `;
 
-const StyledWrapper = styled.div`
-  max-height: 400px;
-  overflow-y: scroll;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-`;
-
 const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
   createdSteps,
   onUpdateSteps,
+  steps,
+  activeStep,
+  onClickStep,
+  onDuplicateStep,
+  disabled,
 }) => {
   const [orderedSteps, setOrderedSteps] = useState(createdSteps?.map((step) => step.step_id));
+  const [activeId, setActiveId] = useState<string | null>(null);
 
   useEffect(() => {
     if (onUpdateSteps) {
@@ -57,22 +64,30 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
+  const handleDragStart = (event: DragStartEvent) => {
+    const { active } = event;
+
+    setActiveId(active.id);
+  };
+
   const handleDragEnd = ({ active, over }: DragEndEvent) => {
     if (over && active.id !== over.id) {
       setOrderedSteps(() => {
-        const stepIds = createdSteps.map((step) => step.step_id as string);
-        const activeStep = createdSteps.find(
-          (step) => `${step.name} - ${step.query_func}` === active.id,
+        const stepIds = steps.toArray().map((step) => step.get('step_id') as string);
+        const activeStep = steps.find(
+          (step) => `${step.get('name')} - ${step.get('query_func')}` === active.id,
         );
-        const overStep = createdSteps.find(
-          (step) => `${step.name} - ${step.query_func}` === over.id,
+        const overStep = steps.find(
+          (step) => `${step.get('name')} - ${step.get('query_func')}` === over.id,
         );
-        const oldIndex = stepIds.indexOf(activeStep ? (activeStep.step_id as string) : '');
-        const newIndex = stepIds.indexOf(overStep ? (overStep.step_id as string) : '');
+        const oldIndex = stepIds.indexOf(activeStep ? (activeStep.get('step_id') as string) : '');
+        const newIndex = stepIds.indexOf(overStep ? (overStep.get('step_id') as string) : '');
 
         return arrayMove(stepIds, oldIndex, newIndex);
       });
     }
+
+    setActiveId(null);
   };
 
   return (
@@ -81,24 +96,44 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
         <i className="material-icons">info</i>{' '}
         <StyledSpan className="d-inline-flex">Drag & drop steps to desired position</StyledSpan>
       </Alert>
-      <StyledWrapper>
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext
-            items={
-              createdSteps ? createdSteps.map((step) => `${step.name} - ${step.query_func}`) : []
-            }
-            strategy={verticalListSortingStrategy}
-          >
-            {createdSteps && createdSteps.length > 0 ? (
-              createdSteps.map((step) => (
-                <SortableItem key={step.step_id} id={`${step.name} - ${step.query_func}`} />
-              ))
-            ) : (
-              <div data-testid="qb-select-no-column-message">No steps selected</div>
-            )}
-          </SortableContext>
-        </DndContext>
-      </StyledWrapper>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={
+            createdSteps ? createdSteps.map((step) => `${step.name} - ${step.query_func}`) : []
+          }
+          strategy={verticalListSortingStrategy}
+        >
+          <Row>
+            <ListGroup variant="flush" className="w-100">
+              {createdSteps && createdSteps.length > 0 ? (
+                createdSteps.map((step, index) => {
+                  return (
+                    <SortableStep
+                      key={index}
+                      id={`${step.name} - ${step.query_func}`}
+                      steps={steps}
+                      step={step}
+                      activeStep={activeStep}
+                      isActiveStep={activeStep && activeStep.get('step_id') === step.step_id}
+                      onClickStep={onClickStep}
+                      onDuplicateStep={onDuplicateStep}
+                      disabled={disabled}
+                    />
+                  );
+                })
+              ) : (
+                <div data-testid="qb-select-no-column-message">No steps selected</div>
+              )}
+            </ListGroup>
+          </Row>
+        </SortableContext>
+        <DragOverlay>{activeId ? <DragOverlayItem id={activeId} /> : null}</DragOverlay>
+      </DndContext>
     </>
   );
 };

--- a/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
+++ b/frontend/src/components/OperationStepsOrder/OperationStepsOrder.tsx
@@ -88,12 +88,6 @@ const OperationStepsOrder: FunctionComponent<StepsOrderProps> = ({
 
   return (
     <>
-      <Alert variant="dark" className="mt-3 p-3 w-50">
-        <i className="material-icons">info</i>{' '}
-        <StyledSpan className="d-inline-flex">
-          Drag & drop steps to desired position with the drag icon on the left of each step.
-        </StyledSpan>
-      </Alert>
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}

--- a/frontend/src/components/OperationStepsOrder/SortableStep.tsx
+++ b/frontend/src/components/OperationStepsOrder/SortableStep.tsx
@@ -11,7 +11,7 @@ import OperationStepView from '../OperationStepView';
 interface SortableStepProps {
   id: string;
   steps: List<OperationStepMap>;
-  step: Step;
+  step: Step | null;
   activeStep?: OperationStepMap;
   isActiveStep?: boolean;
   onClickStep: (step?: OperationStepMap) => void;
@@ -37,7 +37,13 @@ const SortableStep: FunctionComponent<SortableStepProps> = ({
     props.onClickStep(step);
   };
 
-  const currentStep = steps.find((step) => step.get('step_id') === props.step.step_id);
+  const currentStep = steps.find((step) => {
+    if (props.step) {
+      return step.get('step_id') === props.step.step_id;
+    } else {
+      return false;
+    }
+  });
 
   return (
     <StyledStepContainer style={style} ref={setNodeRef} data-testid="qb-select-column-order">
@@ -55,7 +61,7 @@ const SortableStep: FunctionComponent<SortableStepProps> = ({
                 <i className="material-icons mr-1">drag_indicator</i>
               </span>
             </Col>
-            <Col className="w-80" md={11}>
+            <Col className="w-90" md={11}>
               <OperationStepView step={currentStep} onDuplicateStep={props.onDuplicateStep} />
             </Col>
           </Row>

--- a/frontend/src/components/OperationStepsOrder/SortableStep.tsx
+++ b/frontend/src/components/OperationStepsOrder/SortableStep.tsx
@@ -2,7 +2,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { List } from 'immutable';
 import React, { FunctionComponent } from 'react';
-import { Row } from 'react-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 import { OperationStepMap } from '../../types/operations';
 import { StyledListItem, StyledStepContainer } from '../OperationSteps';
 import { Step } from '../OperationSteps/OperationSteps';
@@ -50,10 +50,14 @@ const SortableStep: FunctionComponent<SortableStepProps> = ({
       >
         {currentStep && (
           <Row>
-            <span {...listeners} {...attributes}>
-              <i className="material-icons mr-1">drag_indicator</i>
-            </span>
-            <OperationStepView step={currentStep} onDuplicateStep={props.onDuplicateStep} />
+            <Col md={0.5}>
+              <span className="pl-1" {...listeners} {...attributes}>
+                <i className="material-icons mr-1">drag_indicator</i>
+              </span>
+            </Col>
+            <Col className="w-80" md={11}>
+              <OperationStepView step={currentStep} onDuplicateStep={props.onDuplicateStep} />
+            </Col>
           </Row>
         )}
       </StyledListItem>

--- a/frontend/src/components/OperationStepsOrder/SortableStep.tsx
+++ b/frontend/src/components/OperationStepsOrder/SortableStep.tsx
@@ -1,6 +1,5 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { List } from 'immutable';
 import React, { FunctionComponent } from 'react';
 import { Col, Row } from 'react-bootstrap';
 import { OperationStepMap } from '../../types/operations';
@@ -10,7 +9,7 @@ import OperationStepView from '../OperationStepView';
 
 interface SortableStepProps {
   id: string;
-  steps: List<OperationStepMap>;
+  stepMap: OperationStepMap;
   step: Step | null;
   activeStep?: OperationStepMap;
   isActiveStep?: boolean;
@@ -21,7 +20,7 @@ interface SortableStepProps {
 
 const SortableStep: FunctionComponent<SortableStepProps> = ({
   id,
-  steps,
+  stepMap,
   activeStep,
   isActiveStep,
   ...props
@@ -37,24 +36,16 @@ const SortableStep: FunctionComponent<SortableStepProps> = ({
     props.onClickStep(step);
   };
 
-  const currentStep = steps.find((step) => {
-    if (props.step) {
-      return step.get('step_id') === props.step.step_id;
-    } else {
-      return false;
-    }
-  });
-
   return (
     <StyledStepContainer style={style} ref={setNodeRef} data-testid="qb-select-column-order">
       <StyledListItem
         data-testid="qb-step-wrapper"
         className="py-2"
-        onClick={!activeStep && onClickStep(currentStep as OperationStepMap)}
+        onClick={!activeStep && onClickStep(stepMap as OperationStepMap)}
         disabled={(activeStep && !isActiveStep) || props.disabled}
         active={isActiveStep}
       >
-        {currentStep && (
+        {stepMap && (
           <Row>
             <Col md={0.5}>
               <span className="pl-1" {...listeners} {...attributes}>
@@ -62,7 +53,7 @@ const SortableStep: FunctionComponent<SortableStepProps> = ({
               </span>
             </Col>
             <Col className="w-90" md={11}>
-              <OperationStepView step={currentStep} onDuplicateStep={props.onDuplicateStep} />
+              <OperationStepView step={stepMap} onDuplicateStep={props.onDuplicateStep} />
             </Col>
           </Row>
         )}

--- a/frontend/src/components/OperationStepsOrder/SortableStep.tsx
+++ b/frontend/src/components/OperationStepsOrder/SortableStep.tsx
@@ -53,7 +53,7 @@ const SortableStep: FunctionComponent<SortableStepProps> = ({
         {stepMap && (
           <Row>
             <Col md={0.5} className="mt-auto mb-auto">
-              <span className="pl-2" {...listeners} {...attributes}>
+              <span data-testid="qb-drag-handle" className="pl-2" {...listeners} {...attributes}>
                 <StyledIcon className="material-icons">drag_indicator</StyledIcon>
               </span>
             </Col>

--- a/frontend/src/components/OperationStepsOrder/SortableStep.tsx
+++ b/frontend/src/components/OperationStepsOrder/SortableStep.tsx
@@ -1,0 +1,64 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { List } from 'immutable';
+import React, { FunctionComponent } from 'react';
+import { OperationStepMap } from '../../types/operations';
+import { StyledListItem, StyledStepContainer } from '../OperationSteps';
+import { Step } from '../OperationSteps/OperationSteps';
+import OperationStepView from '../OperationStepView';
+
+interface SortableStepProps {
+  id: string;
+  steps: List<OperationStepMap>;
+  step: Step;
+  activeStep?: OperationStepMap;
+  isActiveStep?: boolean;
+  onClickStep: (step?: OperationStepMap) => void;
+  disabled?: boolean;
+  onDuplicateStep: (step?: OperationStepMap) => void;
+}
+
+const SortableStep: FunctionComponent<SortableStepProps> = ({
+  id,
+  steps,
+  activeStep,
+  isActiveStep,
+  ...props
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition: transition?.toString(),
+  };
+
+  const onClickStep = (step: OperationStepMap) => () => {
+    props.onClickStep(step);
+  };
+
+  const currentStep = steps.find((step) => step.get('step_id') === props.step.step_id);
+
+  return (
+    <StyledStepContainer
+      style={style}
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      data-testid="qb-select-column-order"
+    >
+      <StyledListItem
+        data-testid="qb-step-wrapper"
+        className="py-2"
+        onClick={!activeStep && onClickStep(currentStep as OperationStepMap)}
+        disabled={(activeStep && !isActiveStep) || props.disabled}
+        active={isActiveStep}
+      >
+        {currentStep && (
+          <OperationStepView step={currentStep} onDuplicateStep={props.onDuplicateStep} />
+        )}
+      </StyledListItem>
+    </StyledStepContainer>
+  );
+};
+
+export { SortableStep };

--- a/frontend/src/components/OperationStepsOrder/SortableStep.tsx
+++ b/frontend/src/components/OperationStepsOrder/SortableStep.tsx
@@ -2,6 +2,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { List } from 'immutable';
 import React, { FunctionComponent } from 'react';
+import { Row } from 'react-bootstrap';
 import { OperationStepMap } from '../../types/operations';
 import { StyledListItem, StyledStepContainer } from '../OperationSteps';
 import { Step } from '../OperationSteps/OperationSteps';
@@ -39,13 +40,7 @@ const SortableStep: FunctionComponent<SortableStepProps> = ({
   const currentStep = steps.find((step) => step.get('step_id') === props.step.step_id);
 
   return (
-    <StyledStepContainer
-      style={style}
-      ref={setNodeRef}
-      {...attributes}
-      {...listeners}
-      data-testid="qb-select-column-order"
-    >
+    <StyledStepContainer style={style} ref={setNodeRef} data-testid="qb-select-column-order">
       <StyledListItem
         data-testid="qb-step-wrapper"
         className="py-2"
@@ -54,7 +49,12 @@ const SortableStep: FunctionComponent<SortableStepProps> = ({
         active={isActiveStep}
       >
         {currentStep && (
-          <OperationStepView step={currentStep} onDuplicateStep={props.onDuplicateStep} />
+          <Row>
+            <span {...listeners} {...attributes}>
+              <i className="material-icons mr-1">drag_indicator</i>
+            </span>
+            <OperationStepView step={currentStep} onDuplicateStep={props.onDuplicateStep} />
+          </Row>
         )}
       </StyledListItem>
     </StyledStepContainer>

--- a/frontend/src/components/OperationStepsOrder/SortableStep.tsx
+++ b/frontend/src/components/OperationStepsOrder/SortableStep.tsx
@@ -2,6 +2,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import React, { FunctionComponent } from 'react';
 import { Col, Row } from 'react-bootstrap';
+import styled from 'styled-components';
 import { OperationStepMap } from '../../types/operations';
 import { StyledListItem, StyledStepContainer } from '../OperationSteps';
 import { Step } from '../OperationSteps/OperationSteps';
@@ -17,6 +18,10 @@ interface SortableStepProps {
   disabled?: boolean;
   onDuplicateStep: (step?: OperationStepMap) => void;
 }
+
+const StyledIcon = styled.i`
+  font-size: 18px;
+`;
 
 const SortableStep: FunctionComponent<SortableStepProps> = ({
   id,
@@ -47,9 +52,9 @@ const SortableStep: FunctionComponent<SortableStepProps> = ({
       >
         {stepMap && (
           <Row>
-            <Col md={0.5}>
-              <span className="pl-1" {...listeners} {...attributes}>
-                <i className="material-icons mr-1">drag_indicator</i>
+            <Col md={0.5} className="mt-auto mb-auto">
+              <span className="pl-2" {...listeners} {...attributes}>
+                <StyledIcon className="material-icons">drag_indicator</StyledIcon>
               </span>
             </Col>
             <Col className="w-90" md={11}>

--- a/frontend/src/components/OperationStepsOrder/index.ts
+++ b/frontend/src/components/OperationStepsOrder/index.ts
@@ -1,0 +1,1 @@
+export * from './OperationStepsOrder';

--- a/frontend/src/pages/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/pages/QueryBuilder/QueryBuilder.tsx
@@ -169,6 +169,10 @@ const QueryBuilder: FunctionComponent<QueryBuilderProps> = (props) => {
     props.actions.setActiveOperation(operation, true);
   };
 
+  const onReorderSteps = (step: OperationStepMap) => {
+    props.actions.editOperationStep(step);
+  };
+
   const onDeleteOperation = (operation: OperationMap) => {
     const operationID = operation.get('id') as string | undefined;
     if (operationID) {
@@ -361,6 +365,7 @@ const QueryBuilder: FunctionComponent<QueryBuilderProps> = (props) => {
           editable={editable}
           disabled={showPreview}
           onDuplicateStep={onDuplicateStep}
+          onReorderSteps={onReorderSteps}
         />
       </OperationForm>
     );

--- a/frontend/src/utils/help.ts
+++ b/frontend/src/utils/help.ts
@@ -138,7 +138,10 @@ export const queryBuilderHelpMenuLinks: MenuLink[] = [
   {
     caption: 'Duplicate Step',
     url: `${BASE_URL}1j10m46dLY-zb5Mee4JWncTGeOsf2o8oChSN90ZUu8vk/edit#heading=h.hvjhhaea4v1c`,
-    addDividerAfter: true,
+  },
+  {
+    caption: 'Order Steps',
+    url: `${BASE_URL}1j10m46dLY-zb5Mee4JWncTGeOsf2o8oChSN90ZUu8vk/edit#heading=h.bgki9c380aeq`,
   },
   {
     caption: 'Report Issue',

--- a/frontend/src/utils/help.ts
+++ b/frontend/src/utils/help.ts
@@ -142,6 +142,7 @@ export const queryBuilderHelpMenuLinks: MenuLink[] = [
   {
     caption: 'Order Steps',
     url: `${BASE_URL}1j10m46dLY-zb5Mee4JWncTGeOsf2o8oChSN90ZUu8vk/edit#heading=h.bgki9c380aeq`,
+    addDividerAfter: true,
   },
   {
     caption: 'Report Issue',


### PR DESCRIPTION
Issue #296 


1. Added 2 buttons to the [OperationStepView](https://github.com/devinit/ddw-analyst-ui/blob/feature/order-steps/frontend/src/components/OperationStepView/OperationStepView.tsx#L71) component. They're arrow buttons; move up & move down
2. Clicking the up button moves the step to previous position. The down button does the opposite.
3. The first step doesn't have an up button. The last step doesn't have a down button.