### PR TITLE
Enable spotlights development in dev compose file

### DIFF
--- a/Dockerfile_dev_pg
+++ b/Dockerfile_dev_pg
@@ -1,0 +1,11 @@
+# start with a base image
+FROM postgres:13.2
+LABEL maintainer="akmiller01 <Alex Miller, alex.miller@devinit.org>"
+
+# New users
+ENV POSTGRES_USER=analyst_ui_user
+ENV POSTGRES_PASSWORD=analyst_ui_pass
+
+
+# Add initialization script to initdb
+ADD ./database_setup/dba.sql /docker-entrypoint-initdb.d/

--- a/Dockerfile_dev_pg
+++ b/Dockerfile_dev_pg
@@ -1,6 +1,6 @@
 # start with a base image
 FROM postgres:13.2
-LABEL maintainer="akmiller01 <Alex Miller, alex.miller@devinit.org>"
+LABEL maintainer="wakibi <Chris Wakibi, chrisw@devinit.org>"
 
 # New users
 ENV POSTGRES_USER=analyst_ui_user

--- a/Dockerfile_spotlights_dev
+++ b/Dockerfile_spotlights_dev
@@ -1,0 +1,9 @@
+# FROM node:9-alpine@sha256:1fbcd77d0eb2af765d24ae4758b5a94b0d55c6002a15a4431d55795a449ebd3d as api-release
+FROM node:12-alpine as api-release
+
+RUN mkdir -p /src/ddw-external-api
+WORKDIR /src/ddw-external-api
+
+RUN npm install
+
+CMD npm run dev

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,8 +21,9 @@ services:
     expose:
       - "8000"
     # Replace below path with the path to your ddw-external-api repo
+    # e.g export SPOTLIGHTS_REPO_PATH=/path/to/ddw-external-api
     volumes:
-      - "/Users/boss/chris/git/ddw-external-api:/src/ddw-external-api"
+      - "${SPOTLIGHTS_REPO_PATH}:/src/ddw-external-api"
     ports:
       - "8000:8000"
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,9 +4,29 @@ services:
   db:
     build:
       context: .
-      dockerfile: Dockerfile_pg
+      dockerfile: Dockerfile_dev_pg
     volumes:
       - metadata2:/var/lib/postgresql/data
+    expose:
+      - "5432"
+    ports:
+      - "5432:5432"
+    networks:
+      - ddw_net
+
+  spotlights:
+    build:
+      context: .
+      dockerfile: Dockerfile_spotlights_dev
+    expose:
+      - "8000"
+    # Replace below path with the path to your ddw-external-api repo
+    volumes:
+      - "/Users/boss/chris/git/ddw-external-api:/src/ddw-external-api"
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
     networks:
       - ddw_net
   web:


### PR DESCRIPTION
@edwinmp check this to enable testing spotlights in analyst UI. See the comment I left on line 23 in `docker-compose.dev.yml` file. Also, just run `docker-compose -f docker-compose.dev.yml up spotlights` in case you are testing spotlights strictly. That should save you some resources