### PR TITLE
Disable Slack Integration errors on local development

### DIFF
--- a/core/errors.py
+++ b/core/errors.py
@@ -28,5 +28,5 @@ def handle_uncaught_error(error):
     error_traceback = error.__traceback__
     extracted_traceback = traceback.extract_tb(error_traceback)
     result = traceback.format_list(extracted_traceback)
-    message = result[0]
+    message = ''.join(result)
     post_to_slack_channel(settings.SLACK_CHANNEL_ID, message, f'DDW ANALYST UI {type(error).__name__}')

--- a/ddw_analyst_ui/settings.py
+++ b/ddw_analyst_ui/settings.py
@@ -243,6 +243,9 @@ LOGGING = {
             'level': 'ERROR',
             'class': 'integrations.slack.slack_exception_handler.SlackExceptionHandler',
         },
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
         'null': {
             'class': 'logging.NullHandler',
         },
@@ -263,9 +266,10 @@ LOGGING = {
         'django': {
             'level': 'ERROR',
             'handlers': ['slack_admins'],
+            'propagate': False,
         },
         'integrations': {
-            'handlers': ['logfile'],
+            'handlers': ['console'],
             'level': 'DEBUG',
             'propagate': True,
         },
@@ -275,6 +279,8 @@ LOGGING = {
 if DEBUG:
     # useful if debugging on localhost
     LOGGING['handlers']['slack_admins']['filters'] = ['require_debug_true']
+    # Comment below line to see more verbose logging on console
+    LOGGING['loggers']['django']['handlers'] = ['console']
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 

--- a/integrations/slack/methods.py
+++ b/integrations/slack/methods.py
@@ -52,4 +52,7 @@ def post_to_slack_channel(channel_id, message, subject=None):
             )
             logger.warning("Result: {}".format(str(result)))
         except SlackApiError as error:
-            logger.warning("Error posting to slack: {}".format())
+            if settings.DEBUG:
+                logger.warning("{}".format(message))
+            else:
+                logger.warning("Error posting to slack: {} \n Debug info below \n{}".format(str(error), message))


### PR DESCRIPTION
This disables slack error messages during development.