### PR TITLE
Replace npm ci with npm i on CI build step

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -204,7 +204,7 @@ jobs:
         port: ${{ secrets.PORT }}
         script: |
           cd ~/ddw-analyst-ui
-          npm ci
+          npm i
           npm run build
           docker-compose exec -T web python manage.py collectstatic --no-input
 
@@ -237,7 +237,7 @@ jobs:
     - name: Install dependencies
       run: |
         npm config set '@bit:registry' https://node.bit.dev
-        npm ci
+        npm i
 
     - name: Run end-to-end tests
       run: |


### PR DESCRIPTION
Tested on dev [here](https://github.com/devinit/ddw-analyst-ui/runs/6488969184?check_suite_focus=true) - turns out local `gulp` cannot survive a clean install

Ticket #690 