### PR TITLE
Fix/cd timeout

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -161,6 +161,7 @@ jobs:
         username: ${{ env.USERNAME }}
         key: ${{ secrets.KEY }}
         port: ${{ secrets.PORT }}
+        command_timeout: 30m
         script: |
           chmod 700 "deploy_script.sh"
           ./deploy_script.sh
@@ -173,6 +174,7 @@ jobs:
         username: ${{ env.USERNAME }}
         key: ${{ secrets.KEY }}
         port: ${{ secrets.PORT }}
+        command_timeout: 30m
         script: |
           version=$(echo ${{ steps.get_version.outputs.VERSION }} | cut -c 2-)
           export SITE_URL=${{ env.SITE_URL }}
@@ -188,6 +190,7 @@ jobs:
         username: ${{ env.USERNAME }}
         key: ${{ secrets.KEY }}
         port: ${{ secrets.PORT }}
+        command_timeout: 30m
         script: |
           version=$(echo ${{ steps.get_version.outputs.VERSION }} | cut -c 2-)
           export SITE_URL=${{ env.SITE_URL }}
@@ -202,6 +205,7 @@ jobs:
         username: ${{ env.USERNAME }}
         key: ${{ secrets.KEY }}
         port: ${{ secrets.PORT }}
+        command_timeout: 30m
         script: |
           cd ~/ddw-analyst-ui
           npm -v

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -65,7 +65,7 @@ services:
       - ddw_net
 
   celery:
-    build: .
+    image: ddw-analyst-ui_web:latest
     command: celery -A ddw_analyst_ui worker -l info
     depends_on:
       - web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       - ddw_net
 
   celery:
-    build: .
+    image: ddw-analyst-ui_web:latest
     command: celery -A ddw_analyst_ui worker -l info
     depends_on:
       - web


### PR DESCRIPTION
Handles time out error by;
1. Increasing timeout
2. Using the previously build web image to run celery instead of re-building a fresh celery image yet they use the same dockerfile.