### PR TITLE
Revert "OECD truncate" because table structure changes

### DIFF
--- a/data_updates/R/load_mirrors.R
+++ b/data_updates/R/load_mirrors.R
@@ -48,15 +48,11 @@ chunk_load_table = function(con, table.quote, filename, col.names, quote="\"", s
   index = 0
   message(filename)
   file_con = file(description=filename, open="r", encoding=encoding)
-  table.exists = dbExistsTable(con, name = table.quote)
-  if(allow.overwrite & table.exists){
-    dbExecute(con, statement=paste0('TRUNCATE TABLE "', table.quote[1], '"."', table.quote[2], '"'))
-  }
   repeat{
     index = index + 1
     dataChunk = read.delim(file_con, nrows=chunk.size, skip=0, header=(index==1), sep=sep, col.names=col.names, as.is=T, na.strings=c("\032",""),quote=quote)
     dataChunk = dataChunk[rowSums(is.na(dataChunk)) != ncol(dataChunk),]
-    dbWriteTable(con, name = table.quote, value = dataChunk, row.names = F, overwrite=F, append=T, field.types=field.types)
+    dbWriteTable(con, name = table.quote, value = dataChunk, row.names = F, overwrite=((index==1) & allow.overwrite), append=((index>1) | !allow.overwrite), field.types=field.types)
     if(nrow(dataChunk) != chunk.size){
       break
     }


### PR DESCRIPTION
This reverts commit 8f8c38df523502d101e75bad92ef0e393baadb3e.