### PR TITLE
Fix | Intermittent cypress tests failures

### DIFF
--- a/frontend/cypress/integration/datasets.cy.js
+++ b/frontend/cypress/integration/datasets.cy.js
@@ -184,7 +184,9 @@ describe('The Datasets Pages', () => {
   });
 
   it('makes a copy of my dataset', () => {
-    cy.intercept('/api/datasets/mine/?limit=10&offset=0&search=', { fixture: 'datasets' }).as('getMyDatasets');
+    cy.intercept('/api/datasets/mine/?limit=10&offset=0&search=', { fixture: 'datasets' }).as(
+      'getMyDatasets',
+    );
     cy.visit('/');
     cy.wait('@getMyDatasets');
     checkCopiedDataset('be.checked');
@@ -276,6 +278,11 @@ describe('The Datasets Pages', () => {
   });
 
   it('deletes a frozen dataset', () => {
+    cy.intercept(`/api/dataset/history/*/?limit=10&offset=0`).as('getFrozenDatasets');
+
+    cy.visit('/datasets/');
+    cy.get('.dataset-row').eq(0).contains('Versions').click({ force: true });
+
     // Get initial frozen datasets row count
     cy.get('[data-testid="datasetRows"]')
       .its('length')
@@ -284,7 +291,10 @@ describe('The Datasets Pages', () => {
       });
 
     // Delete frozen dataset
-    cy.get('[data-testid="frozen-dataset-delete-button"]').first().dblclick({ force: true });
+    cy.get('[data-testid="frozen-dataset-delete-button"]')
+      .first()
+      .click({ force: true })
+      .click({ force: true });
     cy.get('@datasetRowNumber').then((datasetRowNumber) => {
       cy.get('[data-testid="datasetRows"]').should('have.length', datasetRowNumber - 1);
     });

--- a/frontend/cypress/integration/datasets.cy.js
+++ b/frontend/cypress/integration/datasets.cy.js
@@ -88,8 +88,7 @@ describe('The Datasets Pages', () => {
 
     cy.wait('@datasets').then((res) => {
       cy.get('.search').first().click({ force: true });
-      cy.wait(4000);
-      cy.get('.search').first().type('FTS dependency codenames{enter}');
+      cy.get('.search').first().type('FTS dependency codenames{enter}', { delay: 200 });
       cy.url().should('eq', `${Cypress.config('baseUrl')}/datasets/?page=1&source=43`);
       cy.get('.text').eq(1).should('have.text', 'FTS dependency codenames');
       cy.getAccessToken().then((token) => {

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -35,12 +35,11 @@ Cypress.Commands.add('login', (email, password) => {
 Cypress.Commands.add('fillOperationForm', (name, description, dataSource = 'CRS ISO codes') => {
   // Visit query builder type name and choose datasource
   cy.visit('/queries/build');
-  cy.wait(5000);
   cy.get('[name="name"]').focus().type(name);
   cy.get('[name="description"]').focus().type(description);
   cy.get('[data-testid="active-data-source"]')
     .click({ force: true })
-    .type(`${dataSource}{downarrow}{downarrow}{enter}`);
+    .type(`${dataSource}{downarrow}{downarrow}{enter}`, { delay: 300 });
   cy.get('.item', { timeout: 10000 }).eq(0).click({ force: true });
 });
 


### PR DESCRIPTION
Issue #695 
**Datasets**
- Add wait when typing in the search bar to allow the list items to get loaded.
- Delete a frozen dataset by using two `click()` commands.

**QueryBuilder.select**
- Add delay to the `cy.type()` command in the _commands.js_ file to fix timeout errors in _queryBuilder.select_ file.

**Datasources**
- Navigate to the sources URL before attempting to get the `.dataset-row` to fix the timeout error.