### PR TITLE
Fix | Hide/Remove Versions Button, Tests

### DIFF
--- a/frontend/cypress/integration/dataSources.cy.js
+++ b/frontend/cypress/integration/dataSources.cy.js
@@ -91,6 +91,23 @@ describe('The Data Sources Page', () => {
       });
     });
 
+    it('versions button is hidden for frozen data sources', () => {
+      cy.visit('/sources');
+      cy.get('[data-testid="sources-dropdown-filter"]').type('frozen{enter}');
+      cy.get('[data-testid="sources-table-row"]')
+        .first()
+        .then(() => {
+          cy.get('[data-testid="source-table-row-actions"]').should('not.contain', 'Versions');
+        });
+
+      cy.get('[data-testid="sources-dropdown-filter"]').type('all{enter}');
+      cy.get('[data-testid="sources-table-row"]')
+        .first()
+        .then(() => {
+          cy.get('[data-testid="source-table-row-actions"]').should('not.contain', 'Versions');
+        });
+    });
+
     xit('actions buttons function properly', () => {
       // TODO: add test
     });

--- a/frontend/cypress/integration/dataSources.cy.js
+++ b/frontend/cypress/integration/dataSources.cy.js
@@ -108,6 +108,36 @@ describe('The Data Sources Page', () => {
         });
     });
 
+    it('filters by dropdown selection', () => {
+      cy.intercept('api/sources/?limit=10&offset=0&search=&frozen=0').as('datasources');
+
+      cy.visit('/sources');
+      cy.url().should('eq', `${Cypress.config('baseUrl')}/sources/`);
+
+      cy.wait('@datasources').then((res) => {
+        cy.get('[data-testid="sources-dropdown-filter"]').type('frozen{enter}');
+        cy.url().should('eq', `${Cypress.config('baseUrl')}/sources/?frozen=1`);
+        cy.get('[data-testid="sources-dropdown-filter"] > .divider').should(
+          'contain',
+          'Frozen Sources',
+        );
+
+        cy.getAccessToken().then((token) => {
+          if (token) {
+            const options = {
+              url: `${Cypress.config('baseUrl')}/api/sources/?&offset=0&frozen=1`,
+              headers: {
+                Authorization: `token ${token.replaceAll('"', '')}`,
+              },
+            };
+            cy.request(options).then((response) => {
+              expect(res.response.body.count).to.not.equal(response.body.count);
+            });
+          }
+        });
+      });
+    });
+
     xit('actions buttons function properly', () => {
       // TODO: add test
     });

--- a/frontend/src/components/SourcesTable/SourcesTable.tsx
+++ b/frontend/src/components/SourcesTable/SourcesTable.tsx
@@ -11,6 +11,7 @@ import { SourcesTableRow } from '../SourcesTableRow';
 interface SourcesTableProps {
   sources: List<SourceMap>;
   activeSource?: SourceMap;
+  value: number;
 }
 export const SourcesTable: FunctionComponent<SourcesTableProps> = (props) => {
   const [showModal, setShowModal] = useState(false);
@@ -41,6 +42,7 @@ export const SourcesTable: FunctionComponent<SourcesTableProps> = (props) => {
           onShowDatasets={onShowDatasets}
           onShowMetadata={onShowMetadata}
           onShowHistory={onShowHistory}
+          value={props.value}
         />
       ));
     }

--- a/frontend/src/components/SourcesTable/SourcesTable.tsx
+++ b/frontend/src/components/SourcesTable/SourcesTable.tsx
@@ -11,7 +11,7 @@ import { SourcesTableRow } from '../SourcesTableRow';
 interface SourcesTableProps {
   sources: List<SourceMap>;
   activeSource?: SourceMap;
-  value: number;
+  value?: number;
 }
 export const SourcesTable: FunctionComponent<SourcesTableProps> = (props) => {
   const [showModal, setShowModal] = useState(false);
@@ -42,7 +42,7 @@ export const SourcesTable: FunctionComponent<SourcesTableProps> = (props) => {
           onShowDatasets={onShowDatasets}
           onShowMetadata={onShowMetadata}
           onShowHistory={onShowHistory}
-          value={props.value}
+          value={props.value as number}
         />
       ));
     }

--- a/frontend/src/components/SourcesTable/SourcesTable.tsx
+++ b/frontend/src/components/SourcesTable/SourcesTable.tsx
@@ -11,7 +11,7 @@ import { SourcesTableRow } from '../SourcesTableRow';
 interface SourcesTableProps {
   sources: List<SourceMap>;
   activeSource?: SourceMap;
-  value?: number;
+  sourceFilterValue?: number;
 }
 export const SourcesTable: FunctionComponent<SourcesTableProps> = (props) => {
   const [showModal, setShowModal] = useState(false);
@@ -42,7 +42,7 @@ export const SourcesTable: FunctionComponent<SourcesTableProps> = (props) => {
           onShowDatasets={onShowDatasets}
           onShowMetadata={onShowMetadata}
           onShowHistory={onShowHistory}
-          value={props.value as number}
+          sourceFilterValue={props.sourceFilterValue as number}
         />
       ));
     }

--- a/frontend/src/components/SourcesTable/__tests__/SourcesTable.spec.tsx
+++ b/frontend/src/components/SourcesTable/__tests__/SourcesTable.spec.tsx
@@ -38,7 +38,7 @@ afterEach(cleanup);
 
 test('renders correctly with default props', () => {
   const renderer = TestRenderer.create(
-    <SourcesTable activeSource={source} sources={sourcesList} />,
+    <SourcesTable activeSource={source} sources={sourcesList} value={0} />,
   ).toJSON();
 
   expect(renderer).toMatchSnapshot();
@@ -46,7 +46,7 @@ test('renders correctly with default props', () => {
 
 test('renders an empty table if no sources are provided', () => {
   const renderer = TestRenderer.create(
-    <SourcesTable activeSource={source} sources={List()} />,
+    <SourcesTable activeSource={source} sources={List()} value={0} />,
   ).toJSON();
 
   expect(renderer).toMatchSnapshot();
@@ -54,7 +54,7 @@ test('renders an empty table if no sources are provided', () => {
 
 test('renders correctly when the sources are updated', () => {
   const { container, rerender } = render(
-    <SourcesTable activeSource={source} sources={sourcesList} />,
+    <SourcesTable activeSource={source} sources={sourcesList} value={0} />,
   );
   sourcesList = sourcesList.push(
     source
@@ -63,7 +63,7 @@ test('renders correctly when the sources are updated', () => {
       .set('indicator_acronym', 'DAC1')
       .set('last_updated_on', new Date('August 19, 2018 23:15:30').toISOString()),
   );
-  rerender(<SourcesTable activeSource={source} sources={sourcesList} />);
+  rerender(<SourcesTable activeSource={source} sources={sourcesList} value={0} />);
 
   expect(container).toMatchSnapshot();
 });

--- a/frontend/src/components/SourcesTable/__tests__/SourcesTable.spec.tsx
+++ b/frontend/src/components/SourcesTable/__tests__/SourcesTable.spec.tsx
@@ -38,7 +38,7 @@ afterEach(cleanup);
 
 test('renders correctly with default props', () => {
   const renderer = TestRenderer.create(
-    <SourcesTable activeSource={source} sources={sourcesList} value={0} />,
+    <SourcesTable activeSource={source} sources={sourcesList} sourceFilterValue={0} />,
   ).toJSON();
 
   expect(renderer).toMatchSnapshot();
@@ -46,7 +46,7 @@ test('renders correctly with default props', () => {
 
 test('renders an empty table if no sources are provided', () => {
   const renderer = TestRenderer.create(
-    <SourcesTable activeSource={source} sources={List()} value={0} />,
+    <SourcesTable activeSource={source} sources={List()} sourceFilterValue={0} />,
   ).toJSON();
 
   expect(renderer).toMatchSnapshot();
@@ -54,7 +54,7 @@ test('renders an empty table if no sources are provided', () => {
 
 test('renders correctly when the sources are updated', () => {
   const { container, rerender } = render(
-    <SourcesTable activeSource={source} sources={sourcesList} value={0} />,
+    <SourcesTable activeSource={source} sources={sourcesList} sourceFilterValue={0} />,
   );
   sourcesList = sourcesList.push(
     source
@@ -63,7 +63,7 @@ test('renders correctly when the sources are updated', () => {
       .set('indicator_acronym', 'DAC1')
       .set('last_updated_on', new Date('August 19, 2018 23:15:30').toISOString()),
   );
-  rerender(<SourcesTable activeSource={source} sources={sourcesList} value={0} />);
+  rerender(<SourcesTable activeSource={source} sources={sourcesList} sourceFilterValue={0} />);
 
   expect(container).toMatchSnapshot();
 });

--- a/frontend/src/components/SourcesTableCard/SourcesTableCard.tsx
+++ b/frontend/src/components/SourcesTableCard/SourcesTableCard.tsx
@@ -21,7 +21,7 @@ interface ComponentProps {
   offset: number;
   links?: LinksMap;
   count: number;
-  value: number;
+  value?: number;
 }
 type SourcesTableCardProps = ComponentProps;
 type TableFilters = {

--- a/frontend/src/components/SourcesTableCard/SourcesTableCard.tsx
+++ b/frontend/src/components/SourcesTableCard/SourcesTableCard.tsx
@@ -21,7 +21,7 @@ interface ComponentProps {
   offset: number;
   links?: LinksMap;
   count: number;
-  value?: number;
+  sourceFilterValue?: number;
 }
 type SourcesTableCardProps = ComponentProps;
 type TableFilters = {
@@ -141,7 +141,7 @@ export const SourcesTableCard: FunctionComponent<SourcesTableCardProps> = (props
           <SourcesTable
             sources={props.sources}
             activeSource={props.activeSource}
-            value={frozenQuery}
+            sourceFilterValue={frozenQuery}
           />
           {renderPagination()}
         </Card.Body>

--- a/frontend/src/components/SourcesTableCard/SourcesTableCard.tsx
+++ b/frontend/src/components/SourcesTableCard/SourcesTableCard.tsx
@@ -132,6 +132,7 @@ export const SourcesTableCard: FunctionComponent<SourcesTableCardProps> = (props
                 value={frozenQuery}
                 options={dropDownValues}
                 onChange={onFilterByFrozenDataSource}
+                data-testid="sources-dropdown-filter"
               />
             </Col>
           </Row>

--- a/frontend/src/components/SourcesTableCard/SourcesTableCard.tsx
+++ b/frontend/src/components/SourcesTableCard/SourcesTableCard.tsx
@@ -21,6 +21,7 @@ interface ComponentProps {
   offset: number;
   links?: LinksMap;
   count: number;
+  value: number;
 }
 type SourcesTableCardProps = ComponentProps;
 type TableFilters = {
@@ -136,7 +137,11 @@ export const SourcesTableCard: FunctionComponent<SourcesTableCardProps> = (props
           </Row>
         </Card.Body>
         <Card.Body>
-          <SourcesTable sources={props.sources} activeSource={props.activeSource} />
+          <SourcesTable
+            sources={props.sources}
+            activeSource={props.activeSource}
+            value={frozenQuery}
+          />
           {renderPagination()}
         </Card.Body>
       </Card>

--- a/frontend/src/components/SourcesTableRow/SourcesTableRow.tsx
+++ b/frontend/src/components/SourcesTableRow/SourcesTableRow.tsx
@@ -9,7 +9,7 @@ export interface SourcesTableRowProps {
   onShowDatasets: (source: SourceMap) => void;
   onShowMetadata: (source: SourceMap) => void;
   onShowHistory: (source: SourceMap) => void;
-  value: number;
+  value?: number;
 }
 
 const StyledTD = styled.td`

--- a/frontend/src/components/SourcesTableRow/SourcesTableRow.tsx
+++ b/frontend/src/components/SourcesTableRow/SourcesTableRow.tsx
@@ -9,7 +9,7 @@ export interface SourcesTableRowProps {
   onShowDatasets: (source: SourceMap) => void;
   onShowMetadata: (source: SourceMap) => void;
   onShowHistory: (source: SourceMap) => void;
-  value?: number;
+  sourceFilterValue?: number;
 }
 
 const StyledTD = styled.td`
@@ -46,7 +46,7 @@ export const SourcesTableRow: FunctionComponent<SourcesTableRowProps> = ({ sourc
           >
             Datasets
           </Button>
-          {props.value === 0 && (
+          {props.sourceFilterValue === 0 && (
             <Button
               variant="dark"
               size="sm"

--- a/frontend/src/components/SourcesTableRow/SourcesTableRow.tsx
+++ b/frontend/src/components/SourcesTableRow/SourcesTableRow.tsx
@@ -9,6 +9,7 @@ export interface SourcesTableRowProps {
   onShowDatasets: (source: SourceMap) => void;
   onShowMetadata: (source: SourceMap) => void;
   onShowHistory: (source: SourceMap) => void;
+  value: number;
 }
 
 const StyledTD = styled.td`
@@ -45,14 +46,16 @@ export const SourcesTableRow: FunctionComponent<SourcesTableRowProps> = ({ sourc
           >
             Datasets
           </Button>
-          <Button
-            variant="dark"
-            size="sm"
-            onClick={() => props.onShowHistory(source)}
-            data-testid="sources-table-history-button"
-          >
-            Versions
-          </Button>
+          {props.value === 0 && (
+            <Button
+              variant="dark"
+              size="sm"
+              onClick={() => props.onShowHistory(source)}
+              data-testid="sources-table-history-button"
+            >
+              Versions
+            </Button>
+          )}
         </ButtonGroup>
       </StyledTD>
     </tr>

--- a/frontend/src/components/SourcesTableRow/__tests__/SourcesTableRow.spec.tsx
+++ b/frontend/src/components/SourcesTableRow/__tests__/SourcesTableRow.spec.tsx
@@ -18,6 +18,19 @@ const props: SourcesTableRowProps = {
   onShowDatasets: jest.fn(),
   onShowMetadata: jest.fn(),
   onShowHistory: jest.fn(),
+  value: 0,
+};
+
+const props1: SourcesTableRowProps = {
+  source: Map({
+    indicator: 'Frozen Common Reporting Standard End-to-end test freeze data source 20230822',
+    indicator_acronym: 'crs',
+    last_updated_on: '2023-08-22T08:38:29.764694Z',
+  }) as SourceMap,
+  onShowDatasets: jest.fn(),
+  onShowMetadata: jest.fn(),
+  onShowHistory: jest.fn(),
+  value: 1,
 };
 
 test('renders correctly with the default props', () => {
@@ -72,4 +85,17 @@ test('history button responds to click events', () => {
   if (button) fireEvent.click(button);
 
   expect(props.onShowHistory).toHaveBeenCalled();
+});
+
+test('history button is hidden for frozen sources', () => {
+  const table = document.createElement('table');
+  const tableBody = document.createElement('tbody');
+  table.appendChild(tableBody);
+  const { getByTestId } = render(<SourcesTableRow {...props1} />, {
+    container: document.body.appendChild(tableBody),
+  });
+
+  const actions = getByTestId('source-table-row-actions') as HTMLElement;
+  expect(actions).toBeDefined();
+  expect(actions).not.toContain('Versions');
 });

--- a/frontend/src/components/SourcesTableRow/__tests__/SourcesTableRow.spec.tsx
+++ b/frontend/src/components/SourcesTableRow/__tests__/SourcesTableRow.spec.tsx
@@ -18,7 +18,7 @@ const props: SourcesTableRowProps = {
   onShowDatasets: jest.fn(),
   onShowMetadata: jest.fn(),
   onShowHistory: jest.fn(),
-  value: 0,
+  sourceFilterValue: 0,
 };
 
 const props1: SourcesTableRowProps = {
@@ -30,7 +30,7 @@ const props1: SourcesTableRowProps = {
   onShowDatasets: jest.fn(),
   onShowMetadata: jest.fn(),
   onShowHistory: jest.fn(),
-  value: 1,
+  sourceFilterValue: 1,
 };
 
 test('renders correctly with the default props', () => {


### PR DESCRIPTION
Fixes issue #703 
- Hide the Version button for Frozen and All sources
- End-to-end test for asserting that the Versions button is hidden
- End-to-end test for validating the dropdown filter