### PR TITLE
Fix | Add wait

### DIFF
--- a/frontend/cypress/integration/datasets.cy.js
+++ b/frontend/cypress/integration/datasets.cy.js
@@ -214,6 +214,7 @@ describe('The Datasets Pages', () => {
 
     // View dataset data in tabular form
     cy.visit('/');
+    cy.wait(20000);
     cy.wait('@datasets');
     cy.get('.dataset-row')
       .eq(16)


### PR DESCRIPTION
This will add a 20 seconds wait time to enable the page to fully load before calling `cy.get()`