### PR TITLE
Try pinning rabbitmq version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - ddw_net
 
   rabbitmq:
-    image: rabbitmq:latest
+    image: rabbitmq:3.11-management-alpine
     ports:
       - 4369:4369
       - 5671:5671


### PR DESCRIPTION
```
# docker-compose logs rabbitmq
Attaching to ddw-analyst-ui_rabbitmq_1
rabbitmq_1    | Failed to create thread: Operation not permitted (1)
rabbitmq_1    | Aborted (core dumped)
rabbitmq_1    | Failed to create thread: Operation not permitted (1)
rabbitmq_1    | Aborted (core dumped)
```